### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dozu-pipeline.yml
+++ b/.github/workflows/dozu-pipeline.yml
@@ -1,5 +1,8 @@
 name: CI/CD pipeline production environment
 
+permissions:
+  contents: read
+
 on:
   # pull_request:
   #   paths:


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-ui-service/security/code-scanning/3](https://github.com/perinst/dozu-ui-service/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the `vercel-deploy` job primarily interacts with repository contents and secrets, it only requires `contents: read` permissions. We will add this block at the workflow level to apply it globally, as no other jobs are defined in the workflow. This ensures that the workflow has the minimal permissions required to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
