### PR TITLE
Potential fix for code scanning alert no. 8: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwind-variants": "^0.3.0",
     "youtubei.js": "^13.3.0",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "sanitize-html": "^2.16.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/src/app/api/website-content/route.ts
+++ b/src/app/api/website-content/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
+import sanitizeHtml from 'sanitize-html';
 
 export async function POST(req: NextRequest) {
   try {
@@ -43,27 +44,14 @@ export async function POST(req: NextRequest) {
  * Extract readable text content from HTML
  */
 function extractTextFromHtml(html: string): string {
-  // Remove script and style tags and their content
-  let text = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, ' ');
-  text = text.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, ' ');
-
-  // Replace HTML tags with line breaks or spaces
-  text = text.replace(/<(br|p|div|h[1-6]|li)[^>]*>/gi, '\n');
-  text = text.replace(/<\/?(span|a|strong|b|i|em)[^>]*>/gi, ' ');
-
-  // Remove all remaining HTML tags
-  text = text.replace(/<[^>]+>/g, ' ');
-
-  // Decode HTML entities
-  text = text.replace(/&nbsp;/g, ' ');
-  text = text.replace(/&amp;/g, '&');
-  text = text.replace(/&lt;/g, '<');
-  text = text.replace(/&gt;/g, '>');
-  text = text.replace(/&quot;/g, '"');
-  text = text.replace(/&#39;/g, "'");
+  // Use sanitize-html to remove unwanted tags and extract text content
+  const sanitizedHtml = sanitizeHtml(html, {
+    allowedTags: [], // Remove all tags
+    allowedAttributes: {}, // Remove all attributes
+  });
 
   // Remove excessive whitespace
-  text = text.replace(/\s+/g, ' ');
+  const text = sanitizedHtml.replace(/\s+/g, ' ').trim();
 
   // Split by line breaks and filter empty lines
   const lines = text


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-ui-service/security/code-scanning/8](https://github.com/perinst/dozu-ui-service/security/code-scanning/8)

To fix the issue, we should replace the custom regular expression-based approach with a well-tested HTML sanitization library, such as `sanitize-html`. This library is specifically designed to handle edge cases and ensure that potentially dangerous HTML content is properly sanitized.

The `extractTextFromHtml` function will be updated to use `sanitize-html` to remove unwanted tags (`<script>`, `<style>`, etc.) and their content. This approach is more robust and secure than relying on custom regular expressions.

**Steps to implement the fix:**
1. Install the `sanitize-html` library.
2. Update the `extractTextFromHtml` function to use `sanitize-html` for removing unwanted tags and extracting text content.
3. Configure `sanitize-html` to allow only safe tags and attributes, or to strip all tags if only plain text is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
