### PR TITLE
hotfix(auth): Changed to not using hardcoded url

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -14,4 +14,6 @@ S3_ACCESS_KEY=''
 S3_SECRET_KEY=''
 
 #Auth - Google login URL
-NEXT_PUBLIC_GOOGLE_OAUTH_URL=https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/userinfo.profile%20https://www.googleapis.com/auth/userinfo.email&access_type=offline&include_granted_scopes=true&response_type=code&redirect_uri=http://localhost:3333/api/auth/google&client_id=960283004591-j93njbhcdi2etnm4t4mqjddk6im52cn4.apps.googleusercontent.com
+
+NEXT_PUBLIC_GOOGLE_REDIRECT_URI=http://localhost:3333/api/auth/google
+NEXT_PUBLIC_OAUTH_CLIENT_ID=960283004591-j93njbhcdi2etnm4t4mqjddk6im52cn4.apps.googleusercontent.com

--- a/src/app/[locale]/auth/login/page.tsx
+++ b/src/app/[locale]/auth/login/page.tsx
@@ -24,7 +24,10 @@ import { useAuth } from '@/contexts/auth/AuthContext';
 import { useSearchParams } from 'next/navigation';
 import { withRouteGuard } from '@/components/guards/RouteGuard';
 
-const googleOAuthURL = process.env.NEXT_PUBLIC_GOOGLE_OAUTH_URL || ''; //todo: replace with actual error tolerant code
+const googleGoogleRedirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI;
+const googleOAuthClientId = process.env.NEXT_PUBLIC_OAUTH_CLIENT_ID;
+const googleOAuthURL = `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/userinfo.profile%20https://www.googleapis.com/auth/userinfo.email&access_type=offline&include_granted_scopes=true&response_type=code
+&redirect_uri=${googleGoogleRedirectUri}&client_id=${googleOAuthClientId}`;
 
 const AuthPage: React.FC = () => {
   const router = useRouter();


### PR DESCRIPTION
Changed google uris to be able to be changed in env files

Related: https://github.com/perinst/dozu-api-service/issues/73 (Log nhầm qua BE:)

Các ENV cần bổ sung cho FE

NEXT_PUBLIC_GOOGLE_REDIRECT_URI
NEXT_PUBLIC_OAUTH_CLIENT_ID

Ví dụ:

NEXT_PUBLIC_GOOGLE_REDIRECT_URI=http://localhost:3333/api/auth/google
NEXT_PUBLIC_OAUTH_CLIENT_ID=960283004591-j93njbhcdi2etnm4t4mqjddk6im52cn4.apps.googleusercontent.com