### PR TITLE
Feature/re gen method learning

### DIFF
--- a/src/app/[locale]/flashcards/components/FlashcardEditor.tsx
+++ b/src/app/[locale]/flashcards/components/FlashcardEditor.tsx
@@ -27,6 +27,15 @@ import FlashcardImportModal from './import/FlashcardImportModal';
 import { IFlashcardPreview } from './import/FlashcardPreview';
 import ImagesPreviewModal, { IUnspashImage } from './ImagesPreview';
 import { IFlashcard as IFlashcardType } from '../types/flashcard.type';
+import { useGenerateFromExisting } from '@/app/[locale]/generate/hooks/useGenerateFromExisting';
+import { buildContentFromFlashcardsForQuiz } from '@/app/[locale]/question/utils/buildGenPayload';
+import ContentGenerationPreview from '@/app/[locale]/generate/components/ContentGenerationPreview';
+import { useContentGeneration } from '@/app/[locale]/generate/hooks/useContentGeneration';
+import { CONTENT_TYPE_GENERATE } from '@/app/[locale]/generate/types';
+import { handleConvertToQuestionsSubmitted } from '@/app/[locale]/question/utils/handleConvertToQuestionsSubmitted';
+import { postRequest } from '@/api/api';
+
+
 
 interface IFlashcard {
     id: number;
@@ -217,6 +226,8 @@ const FlashcardEditor = ({
     const [isAddImageModalOpen, setIsAddImageModalOpen] = useState<boolean>(false);
     const [selectingFlashcard, setSelectingFlashcard] = useState<IFlashcard | null>();
     const [imagesPreview, setImagesPreview] = useState<IUnspashImage[] | null>(null);
+    const { regenerate, previewOpen, setPreviewOpen, sseData, sseStatus } = useGenerateFromExisting();
+    const { contentType, dataGenerated, setDataGenerated, isContentReady } = useContentGeneration({ sseData, sseStatus });
 
     const { loading: batchLoading, execute: batchFlashcards } = usePost<
         { topicId: string | number; flashcards: IFlashcardsBatchInput },
@@ -493,7 +504,49 @@ const FlashcardEditor = ({
         setFlashcards(newFlashcards);
         setIsAddImageModalOpen(false);
         toastHelper.showSuccessMessage('Insert image into card successfully');
+    } 
+
+    function getUsableFlashcardsForGen(cards: IFlashcardWithServer[]) {
+       return cards.filter(
+         (c) =>
+         !c.serverInfo?.isDeleted &&
+         c.front.trim() !== '' &&
+         c.back.trim() !== ''
+        );
     }
+
+    function hasAnyValidFlashcard(cards: IFlashcardWithServer[]) {
+      return getUsableFlashcardsForGen(cards).length > 0;
+    }
+
+
+    const handleGenerateQuiz = async () => {
+       if (!topic) return;
+         if (!hasAnyValidFlashcard(flashcards)) {
+           toast({ description: 'No valid flashcards to create quiz', variant: 'destructive' });
+           return;
+         }
+       const payload = buildContentFromFlashcardsForQuiz(topic.topicId, flashcards);
+       await regenerate(payload, 'quiz');
+    };
+
+    const handleSaveGeneratedToThisTopic = async () => {
+       if (!topic) return;
+       if (!isContentReady || !dataGenerated) {
+         toast({ description: 'No data to save', variant: 'destructive' });
+         return;
+       }
+
+       if (contentType === CONTENT_TYPE_GENERATE.QUIZ) {
+           const batchQuestions = handleConvertToQuestionsSubmitted(dataGenerated as any);
+           if (!batchQuestions) {
+             toast({ description: 'There are no valid questions to save.', variant: 'destructive' });
+             return;
+            }
+        await postRequest(`/questions/batch?topicId=${topic.topicId}`, batchQuestions);
+        toast({ description: 'Saved Questions to topic', variant: 'default' });
+        }
+    };
 
     if (!flashcards) {
         return <div>No Flashcards found</div>;
@@ -509,6 +562,10 @@ const FlashcardEditor = ({
                     </div>
                 </div>
                 <div className="flex flex-row gap-4">
+                    <Button className="flex flex-row items-center" onClick={handleGenerateQuiz} disabled={!hasAnyValidFlashcard(flashcards)}>
+                       Generate Quiz
+                    </Button>
+
                     <Button className="flex flex-row items-center" onClick={handleImportModalOpen}>
                         <Import size={24} />
                         <div className="text-base">{tFlashcardEdit('import')}</div>
@@ -598,8 +655,30 @@ const FlashcardEditor = ({
                 loading={searchImagesLoading}
                 handleSaveClick={handleSaveImageClick}
             />
+
+            {previewOpen && (
+                <div className="mt-6">
+                   <ContentGenerationPreview
+                     shouldCreateTopic={false}
+                     sseData={sseData}
+                     dataGenerated={dataGenerated}
+                     setDataGenerated={setDataGenerated}
+                     onSave={handleSaveGeneratedToThisTopic}
+                    />
+                    <div className="mt-4 flex gap-3">
+                     <Button onClick={handleSaveGeneratedToThisTopic} disabled={!isContentReady} >Save to this topic</Button>
+                     <Button variant="outline"
+                     onClick={() => {
+                       setPreviewOpen(false);
+                       setDataGenerated(null);
+                     }}>Close</Button>
+                    </div>
+                </div>
+            )}
         </div>
+
     );
+    
 };
 
 export default FlashcardEditor;

--- a/src/app/[locale]/generate/components/ContentRender.tsx
+++ b/src/app/[locale]/generate/components/ContentRender.tsx
@@ -24,7 +24,7 @@ const ContentRender: React.FC<ContentRenderProps> = ({ content, dataGenerated, s
                         setFlashcards={setDataGenerated}
                     />
                 );
-            case CONTENT_TYPE_GENERATE.QUIZ || CONTENT_TYPE_GENERATE.MULTIPLE_CHOICE:
+            case CONTENT_TYPE_GENERATE.QUIZ:
                 return <QuestionRenderer questions={dataGenerated as IQuestion[]} setQuestions={setDataGenerated} />;
             case CONTENT_TYPE_GENERATE.MIND_MAP:
                 return <MindmapRenderer data={content.data} setDataGenerated={setDataGenerated} />;

--- a/src/app/[locale]/generate/hooks/useGenerateFromExisting.ts
+++ b/src/app/[locale]/generate/hooks/useGenerateFromExisting.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import usePost from '@/hooks/usePost';
+import { useEventSource } from '@/hooks/useEventSource';
+import { compressContent } from '@/app/[locale]/generate/helper/compress';
+import { toast } from '@/hooks/use-toast';
+import { ApiResponsePubGenContent, ISseData } from '@/app/[locale]/generate/types';
+import { URL_API_GENERATE } from '@/app/[locale]/generate/utils/constant';
+
+type TargetType = 'flashcard' | 'quiz';
+
+export function useGenerateFromExisting() {
+    const [jobId, setJobId] = useState<string | undefined>();
+    const [targetType, setTargetType] = useState<TargetType | null>(null);
+    const [previewOpen, setPreviewOpen] = useState(false);
+
+    const {
+        loading,
+        data: apiResponse,
+        error: apiPostError,
+        execute,
+    } = usePost<unknown, ApiResponsePubGenContent>(URL_API_GENERATE, 'POST');
+
+    const { data: sseData, status: sseStatus } = useEventSource<ISseData>(
+        jobId ? `/event/generate/job/${jobId}` : null,
+    );
+
+    useEffect(() => {
+        if (apiResponse?.data?.jobId) setJobId(apiResponse.data.jobId);
+    }, [apiResponse]);
+
+    useEffect(() => {
+        if (apiPostError) {
+            toast({ description: String(apiPostError), variant: 'destructive' });
+        }
+    }, [apiPostError]);
+
+    useEffect(() => {
+        if (sseStatus === 'timeout' || sseStatus === 'error') {
+            toast({
+                description: sseStatus === 'timeout' ? 'Waiting time out' : 'Error getting results',
+                variant: 'destructive',
+            });
+        }
+        const payloadStatus = (sseData as any)?.status ?? (sseData as any)?.data?.status; 
+
+        if (sseStatus === 'completed' || payloadStatus === 'completed') {
+            setPreviewOpen(true);
+            toast({ description: 'Content created', variant: 'default' });
+        }
+    }, [sseStatus, sseData]);
+
+    const regenerate = async (contentString: string, type: TargetType) => {
+        setTargetType(type);
+        const compressed = compressContent(contentString);
+        await execute({
+            content: compressed,
+            method: 'text',
+            type,
+        });
+    };
+
+    return {
+        regenerate,
+        targetType,
+        previewOpen,
+        setPreviewOpen,
+        jobId,
+        sseData,
+        sseStatus,
+        loading,
+    };
+}

--- a/src/app/[locale]/question/components/QuestionEditor.tsx
+++ b/src/app/[locale]/question/components/QuestionEditor.tsx
@@ -11,173 +11,248 @@ import { IQuestion } from '@/app/[locale]/question/types/question.type';
 import { handleConvertToQuestionsSubmitted } from '@/app/[locale]/question/utils/handleConvertToQuestionsSubmitted';
 import { ROUTES } from '@/utils/constants/routes';
 import QuestionCard from '../components/QuestionCard';
+import { useGenerateFromExisting } from '@/app/[locale]/generate/hooks/useGenerateFromExisting';
+import { buildContentFromQuestionsForFlashcards } from '@/app/[locale]/question/utils/buildGenPayload';
+import ContentGenerationPreview from '@/app/[locale]/generate/components/ContentGenerationPreview';
+import { useContentGeneration } from '@/app/[locale]/generate/hooks/useContentGeneration';
+import { CONTENT_TYPE_GENERATE } from '@/app/[locale]/generate/types';
+import { handleConvertToFlashcardsSubmitted } from '@/app/[locale]/flashcards/components/FlashcardEditor';
+import flashcardService from '@/services/flashcard/flashcard.service';
 
 const questionsJump = 3;
 
 function createInitialQuestion(id: number): IQuestion {
-  return {
-    id,
-    questionText: '',
-    choices: ['', '', '', ''],
-    correctIndex: 0,
-  };
+    return {
+        id,
+        questionText: '',
+        choices: ['', '', '', ''],
+        correctIndex: 0,
+    };
 }
 
 interface Props {
-  shouldShowBackButton?: boolean;
-  shouldShowSaveButton?: boolean;
-  questions: IQuestion[];
-  setQuestions: (questions: IQuestion[]) => void;
-  topic?: {
-    topicId: string | number;
-    name: string;
-  };
+    shouldShowBackButton?: boolean;
+    shouldShowSaveButton?: boolean;
+    questions: IQuestion[];
+    setQuestions: (questions: IQuestion[]) => void;
+    topic?: {
+        topicId: string | number;
+        name: string;
+    };
 }
 
 const QuestionEditor = ({
-  shouldShowBackButton = true,
-  shouldShowSaveButton = true,
-  questions,
-  setQuestions,
-  topic,
+    shouldShowBackButton = true,
+    shouldShowSaveButton = true,
+    questions,
+    setQuestions,
+    topic,
 }: Props) => {
-  const router = useRouter();
+    const router = useRouter();
+    const { regenerate, previewOpen, setPreviewOpen, sseData, sseStatus } = useGenerateFromExisting();
+    const { contentType, dataGenerated, setDataGenerated, isContentReady } = useContentGeneration({
+        sseData,
+        sseStatus,
+    });
 
-  // 🚀 Khởi tạo nếu chưa có dữ liệu ban đầu
-  useEffect(() => {
-    if (questions.length === 0) {
-      const initial = Array.from({ length: questionsJump }, (_, i) =>
-        createInitialQuestion(i)
-      );
-      setQuestions(initial);
-    }
-  }, []);
-
-  const handleAddQuestions = () => {
-    const lastId = questions.length > 0 ? Math.max(...questions.map((q) => q.id)) : -1;
-    const newQuestions = Array.from({ length: questionsJump }, (_, i) =>
-      createInitialQuestion(lastId + i + 1)
-    );
-    setQuestions([...questions, ...newQuestions]);
-  };
-
-  const handleChangeQuestionText = (order: number, text: string) => {
-    setQuestions(
-      questions.map((q, i) =>
-        i === order
-          ? {
-              ...q,
-              questionText: text,
-              serverInfo: q.serverInfo ? { ...q.serverInfo, isUpdated: true } : q.serverInfo,
-            }
-          : q
-      )
-    );
-  };
-
-  const handleChangeChoice = (questionIdx: number, choiceIdx: number, text: string) => {
-    setQuestions(
-      questions.map((q, i) => {
-        if (i !== questionIdx) return q;
-        const updatedChoices = [...q.choices];
-        updatedChoices[choiceIdx] = text;
-        return {
-          ...q,
-          choices: updatedChoices,
-          serverInfo: q.serverInfo ? { ...q.serverInfo, isUpdated: true } : q.serverInfo,
-        };
-      })
-    );
-  };
-
-  const handleChangeCorrectIndex = (questionIdx: number, correctIdx: number) => {
-    setQuestions(
-      questions.map((q, i) =>
-        i === questionIdx
-          ? {
-              ...q,
-              correctIndex: correctIdx,
-              serverInfo: q.serverInfo ? { ...q.serverInfo, isUpdated: true } : q.serverInfo,
-            }
-          : q
-      )
-    );
-  };
-
-  const handleDeleteQuestion = (id: number) => {
-    const updatedQuestions = questions
-      .map((q) => {
-        if (q.id !== id) return q;
-        if (q.serverInfo) {
-          return {
-            ...q,
-            serverInfo: {
-              ...q.serverInfo,
-              isDeleted: true,
-            },
-          };
+    useEffect(() => {
+        if (questions.length === 0) {
+            const initial = Array.from({ length: questionsJump }, (_, i) => createInitialQuestion(i));
+            setQuestions(initial);
         }
-        return null;
-      })
-      .filter((q): q is IQuestion => q !== null);
+    }, []);
 
-    setQuestions(updatedQuestions);
-  };
+    const handleAddQuestions = () => {
+        const lastId = questions.length > 0 ? Math.max(...questions.map((q) => q.id)) : -1;
+        const newQuestions = Array.from({ length: questionsJump }, (_, i) => createInitialQuestion(lastId + i + 1));
+        setQuestions([...questions, ...newQuestions]);
+    };
 
-  const handleOnClickSave = async () => {
-    const dataSubmitted = handleConvertToQuestionsSubmitted(questions);
-    try {
-      await postRequest(`/questions/batch?topicId=${topic?.topicId}`, dataSubmitted);
-      toast({ title: 'Questions saved successfully' });
-      router.push(ROUTES.HOME);
-    } catch (err) {
-      console.error(err);
-      toast({ title: 'Error saving questions', variant: 'destructive' });
-    }
-  };
+    const handleChangeQuestionText = (order: number, text: string) => {
+        setQuestions(
+            questions.map((q, i) =>
+                i === order
+                    ? {
+                          ...q,
+                          questionText: text,
+                          serverInfo: q.serverInfo ? { ...q.serverInfo, isUpdated: true } : q.serverInfo,
+                      }
+                    : q,
+            ),
+        );
+    };
 
-  return (
-    <div className="px-[4rem] py-7 bg-muted">
-      <div className="flex justify-between items-center">
-        <div className="flex items-center gap-4">
-          {shouldShowBackButton && <BackButton />}
-          <h1 className="text-[1.7rem] font-bold text-primary">
-            {topic ? topic.name : 'Questions Generated'}
-          </h1>
+    const handleChangeChoice = (questionIdx: number, choiceIdx: number, text: string) => {
+        setQuestions(
+            questions.map((q, i) => {
+                if (i !== questionIdx) return q;
+                const updatedChoices = [...q.choices];
+                updatedChoices[choiceIdx] = text;
+                return {
+                    ...q,
+                    choices: updatedChoices,
+                    serverInfo: q.serverInfo ? { ...q.serverInfo, isUpdated: true } : q.serverInfo,
+                };
+            }),
+        );
+    };
+
+    const handleChangeCorrectIndex = (questionIdx: number, correctIdx: number) => {
+        setQuestions(
+            questions.map((q, i) =>
+                i === questionIdx
+                    ? {
+                          ...q,
+                          correctIndex: correctIdx,
+                          serverInfo: q.serverInfo ? { ...q.serverInfo, isUpdated: true } : q.serverInfo,
+                      }
+                    : q,
+            ),
+        );
+    };
+
+    const handleDeleteQuestion = (id: number) => {
+        const updatedQuestions = questions
+            .map((q) => {
+                if (q.id !== id) return q;
+                if (q.serverInfo) {
+                    return {
+                        ...q,
+                        serverInfo: {
+                            ...q.serverInfo,
+                            isDeleted: true,
+                        },
+                    };
+                }
+                return null;
+            })
+            .filter((q): q is IQuestion => q !== null);
+
+        setQuestions(updatedQuestions);
+    };
+
+    const handleOnClickSave = async () => {
+        const dataSubmitted = handleConvertToQuestionsSubmitted(questions);
+        try {
+            await postRequest(`/questions/batch?topicId=${topic?.topicId}`, dataSubmitted);
+            toast({ title: 'Questions saved successfully' });
+            router.push(ROUTES.HOME);
+        } catch (err) {
+            console.error(err);
+            toast({ title: 'Error saving questions', variant: 'destructive' });
+        }
+    };
+
+    const hasAnyValidQuestion = (list: IQuestion[]) => {
+        return list.some(
+            (q) =>
+                !q.serverInfo?.isDeleted &&
+                q.questionText.trim().length > 0 &&
+                Array.isArray(q.choices) &&
+                q.choices.some((c) => (c ?? '').trim().length > 0),
+        );
+    };
+
+    const handleGenerateFlashcards = async () => {
+        if (!topic) return;
+
+        if (!hasAnyValidQuestion(questions)) {
+            toast({ description: 'There are no questions to create flashcards', variant: 'destructive' });
+            return;
+        }
+
+        const payload = buildContentFromQuestionsForFlashcards(topic.topicId, questions);
+        await regenerate(payload, 'flashcard');
+    };
+
+    const handleSaveGeneratedToThisTopic = async () => {
+        if (!topic) return;
+        if (!isContentReady || !dataGenerated) {
+            toast({ description: 'No data to save', variant: 'destructive' });
+            return;
+        }
+
+        if (contentType === CONTENT_TYPE_GENERATE.FLASH_CARD) {
+            const batchFlashcards = handleConvertToFlashcardsSubmitted(dataGenerated as any);
+            if (!batchFlashcards) {
+                toast({ description: 'No valid flashcards to save', variant: 'destructive' });
+                return;
+            }
+            await flashcardService.batchFlashcardsForTopic({ topicId: topic.topicId, flashcards: batchFlashcards });
+            toast({ description: 'Saved Flashcards to topic', variant: 'default' });
+        }
+    };
+
+    return (
+        <div className="px-[4rem] py-7 bg-muted">
+            <div className="flex justify-between items-center">
+                <div className="flex items-center gap-4">
+                    {shouldShowBackButton && <BackButton />}
+                    <h1 className="text-[1.7rem] font-bold text-primary">
+                        {topic ? topic.name : 'Questions Generated'}
+                    </h1>
+                </div>
+                <div className="flex gap-4">
+                    <Button onClick={handleGenerateFlashcards} disabled={!hasAnyValidQuestion(questions)}>
+                        Generate Flashcards
+                    </Button>
+                    <Button>
+                        <Import size={24} /> Import
+                    </Button>
+                    {shouldShowSaveButton && (
+                        <Button onClick={handleOnClickSave}>
+                            <Save size={24} /> Save
+                        </Button>
+                    )}
+                </div>
+            </div>
+
+            <div className="grid grid-cols-12 gap-8 mt-7">
+                {questions
+                    .filter((q) => !q.serverInfo?.isDeleted)
+                    .map((question, index) => (
+                        <QuestionCard
+                            key={question.id}
+                            question={question}
+                            index={index}
+                            onChangeText={handleChangeQuestionText}
+                            onChangeChoice={handleChangeChoice}
+                            onChangeCorrectIndex={handleChangeCorrectIndex}
+                            onDelete={handleDeleteQuestion}
+                        />
+                    ))}
+
+                <div className="col-span-12 flex justify-center">
+                    <Button onClick={handleAddQuestions}>+ Add Questions</Button>
+                </div>
+            </div>
+            {previewOpen && (
+                <div className="mt-6">
+                    <ContentGenerationPreview
+                        shouldCreateTopic={false}
+                        sseData={sseData}
+                        dataGenerated={dataGenerated}
+                        setDataGenerated={setDataGenerated}
+                        onSave={handleSaveGeneratedToThisTopic}
+                    />
+                    <div className="mt-4 flex gap-3">
+                        <Button onClick={handleSaveGeneratedToThisTopic} disabled={!isContentReady}>
+                            Save to this topic
+                        </Button>
+                        <Button
+                            variant="outline"
+                            onClick={() => {
+                                setPreviewOpen(false);
+                                setDataGenerated(null);
+                            }}
+                        >
+                            Close
+                        </Button>
+                    </div>
+                </div>
+            )}
         </div>
-        <div className="flex gap-4">
-          <Button>
-            <Import size={24} /> Import
-          </Button>
-          {shouldShowSaveButton && (
-            <Button onClick={handleOnClickSave}>
-              <Save size={24} /> Save
-            </Button>
-          )}
-        </div>
-      </div>
-
-      <div className="grid grid-cols-12 gap-8 mt-7">
-        {questions
-          .filter((q) => !q.serverInfo?.isDeleted)
-          .map((question, index) => (
-            <QuestionCard
-              key={question.id}
-              question={question}
-              index={index}
-              onChangeText={handleChangeQuestionText}
-              onChangeChoice={handleChangeChoice}
-              onChangeCorrectIndex={handleChangeCorrectIndex}
-              onDelete={handleDeleteQuestion}
-            />
-          ))}
-
-        <div className="col-span-12 flex justify-center">
-          <Button onClick={handleAddQuestions}>+ Add Questions</Button>
-        </div>
-      </div>
-    </div>
-  );
+    );
 };
 
 export default QuestionEditor;

--- a/src/app/[locale]/question/utils/buildGenPayload.ts
+++ b/src/app/[locale]/question/utils/buildGenPayload.ts
@@ -1,0 +1,38 @@
+import { IFlashcardWithServer } from '@/app/[locale]/flashcards/components/FlashcardEditor';
+import { IQuestion } from '@/app/[locale]/question/types/question.type';
+
+export const buildContentFromFlashcardsForQuiz = (
+  topicId: string | number,
+  flashcards: IFlashcardWithServer[]
+): string => {
+  const items = (flashcards ?? [])
+    .filter(c => !c.serverInfo?.isDeleted)
+    .map(({ front, back }) => ({ q: (front ?? '').trim(), a: (back ?? '').trim() }))
+    .filter(x => x.q && x.a);
+
+  return JSON.stringify({
+    source: 'FLASH_CARD',
+    topicId,
+    flashcards: items, // [{ q, a }]
+  });
+};
+
+export const buildContentFromQuestionsForFlashcards = (
+  topicId: string | number,
+  questions: IQuestion[]
+): string => {
+  const items = (questions ?? [])
+    .filter(q => !(q as any).serverInfo?.isDeleted)
+    .map(q => ({
+      questionText: (q.questionText ?? '').trim(),
+      choices: (q.choices ?? []).map(c => (c ?? '').trim()),
+      correctIndex: typeof q.correctIndex === 'number' ? q.correctIndex : 0,
+    }))
+    .filter(x => x.questionText && x.choices?.length > 0);
+
+  return JSON.stringify({
+    source: 'QUIZ',
+    topicId,
+    questions: items, // [{ questionText, choices, correctIndex }]
+  });
+};

--- a/src/app/[locale]/quiz/[topicId]/quiz-type/page.tsx
+++ b/src/app/[locale]/quiz/[topicId]/quiz-type/page.tsx
@@ -30,6 +30,8 @@ const QuizTypePage = () => {
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
     const [showOnboarding, setShowOnboarding] = useState(false);
     const [statistics, setStatistics] = useState<IQuizStatistics | null>(null);
+    const [defaultName, setDefaultName] = useState('');
+    const [defaultDescription, setDefaultDescription] = useState('');
 
     useEffect(() => {
         const fetchStatistics = async () => {
@@ -66,6 +68,26 @@ const QuizTypePage = () => {
                 });
                 return;
             }
+
+            const typeLabels: Record<'initial' | 'review' | 'ef_low' | 'new' | 'random' | 'wrong', string> = {
+                initial: 'Initial',
+                review: 'Review',
+                ef_low: 'EF Low',
+                new: 'New',
+                random: 'Random',
+                wrong: 'Wrong',
+            };
+            const typeLabel = typeLabels[type as keyof typeof typeLabels] || type;
+
+            const now = new Date();
+            const ts =
+                `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ` +
+                `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+
+            setDefaultName(`${typeLabel} Quiz - ${ts}`);
+            setDefaultDescription(
+                `Auto-generated (${data.length} questions). You can rename or edit this description before starting.`,
+            );
 
             setSelectedType(type);
             setIsModalOpen(true);
@@ -168,6 +190,8 @@ const QuizTypePage = () => {
                 onClose={() => setIsModalOpen(false)}
                 onSubmit={handleCreateQuiz}
                 quizType={selectedType}
+                defaultName={defaultName}
+                defaultDescription={defaultDescription}
             />
 
             <QuizOnboarding open={showOnboarding} onOpenChange={setShowOnboarding} />

--- a/src/app/[locale]/quiz/components/CreateQuizModal.tsx
+++ b/src/app/[locale]/quiz/components/CreateQuizModal.tsx
@@ -1,70 +1,75 @@
 'use client';
 
-import { useState } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog';
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 
 interface CreateQuizModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSubmit: (quizData: { name: string; description?: string }) => void;
-  quizType: string;
+    isOpen: boolean;
+    onClose: () => void;
+    onSubmit: (quizData: { name: string; description?: string }) => void;
+    quizType: string;
+    defaultName?: string;
+    defaultDescription?: string;
 }
 
 const CreateQuizModal = ({
-  isOpen,
-  onClose,
-  onSubmit,
-  quizType,
+    isOpen,
+    onClose,
+    onSubmit,
+    quizType,
+    defaultName = '',
+    defaultDescription = '',
 }: CreateQuizModalProps) => {
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [loading, setLoading] = useState(false);
+    const [name, setName] = useState(defaultName);
+    const [description, setDescription] = useState(defaultDescription);
+    const [loading, setLoading] = useState(false);
 
-  const handleSubmit = () => {
-    if (!name.trim()) return;
-    setLoading(true);
-    onSubmit({ name, description });
-    setLoading(false);
-    onClose();
-  };
+    useEffect(() => {
+        if (isOpen) {
+            setName(defaultName);
+            setDescription(defaultDescription);
+        }
+    }, [isOpen, defaultName, defaultDescription]);
 
-  return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Create Quiz - Type: {quizType}</DialogTitle>
-        </DialogHeader>
+    const handleSubmit = async () => {
+        if (!name.trim()) return;
+        try {
+            setLoading(true);
+            await onSubmit({ name: name.trim(), description: description?.trim() });
+            setLoading(false);
+            onClose();
+        } finally {
+            setLoading(false);
+        }
+    };
 
-        <div className="space-y-4">
-          <Input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Quiz name"
-          />
-          <Textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Description"
-          />
-        </div>
+    return (
+        <Dialog open={isOpen} onOpenChange={onClose}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Create Quiz — Type: {quizType}</DialogTitle>
+                </DialogHeader>
 
-        <DialogFooter className="mt-4">
-          <Button onClick={handleSubmit} disabled={loading}>
-            {loading ? 'Creating...' : 'Save Quiz'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
+                <div className="space-y-4">
+                    <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Quiz name" />
+                    <Textarea
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        placeholder="Description"
+                    />
+                </div>
+
+                <DialogFooter className="mt-4">
+                    <Button onClick={handleSubmit} disabled={loading || !name.trim()}>
+                        {loading ? 'Creating...' : 'Save Quiz'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
 };
 
 export default CreateQuizModal;


### PR DESCRIPTION
Allow re-generate Flashcards from Questions and re-generate Quiz from Flashcards right in existing edit pages.

No change to BE: reuse old API POST /generate/v3/text/llm (method=text, type=flashcard|quiz) + SSE /event/generate/job/${jobId}.

Add FE preview after gen is finished, and save directly to current topic via corresponding batch API.

Add validation (no gen without valid data) + UX (disable Save button when no result, reset preview when closing).