### PR TITLE
Potential fix for code scanning alert no. 6: Double escaping or unescaping

### DIFF
--- a/src/app/api/website-content/route.ts
+++ b/src/app/api/website-content/route.ts
@@ -56,11 +56,11 @@ function extractTextFromHtml(html: string): string {
 
   // Decode HTML entities
   text = text.replace(/&nbsp;/g, ' ');
-  text = text.replace(/&amp;/g, '&');
   text = text.replace(/&lt;/g, '<');
   text = text.replace(/&gt;/g, '>');
   text = text.replace(/&quot;/g, '"');
   text = text.replace(/&#39;/g, "'");
+  text = text.replace(/&amp;/g, '&');
 
   // Remove excessive whitespace
   text = text.replace(/\s+/g, ' ');


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-ui-service/security/code-scanning/6](https://github.com/perinst/dozu-ui-service/security/code-scanning/6)

To fix the issue, the unescaping of `&amp;` should be moved to the end of the sequence of replacements. This ensures that the ampersand character is unescaped only after all other entities have been processed, preventing double unescaping. The fix involves reordering the lines in the `extractTextFromHtml` function where HTML entities are replaced.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text decoding for website content to resolve HTML entities in a more reliable order. Prevents occasional misrendering of characters such as ampersands (&) and apostrophes (') in extracted text, resulting in cleaner, more readable content in edge cases and improved consistency across pages. No changes to public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->