### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dozu-pipeline.yml
+++ b/.github/workflows/dozu-pipeline.yml
@@ -1,5 +1,7 @@
 name: CI/CD pipeline production environment
 
+permissions:
+  contents: read
 on:
   # pull_request:
   #   paths:


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-ui-service/security/code-scanning/3](https://github.com/perinst/dozu-ui-service/security/code-scanning/3)

To fix the issue, explicitly set the minimal required permissions for the workflow.  
The best approach is to add a `permissions:` block at the top level of the workflow file, immediately after the `name:` (and possibly after `on:` if following best practices), to apply to all jobs unless overridden. For this workflow, which only needs to read code, set `contents: read`. This should be done in the `.github/workflows/dozu-pipeline.yml` file, near the start.

No imports, methods, or definitions are needed. Only a single insertion of the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to read-only at the workflow level, reducing token scope and aligning with least-privilege best practices.
  * Improves security of automation without altering builds, deployments, or release behavior.
  * No user-facing changes; application functionality and performance remain unchanged.
  * No action required from users or admins.
  * Maintains existing pipeline triggers and environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->