### PR TITLE
feat(quiz-learning): offer quick local quiz after each 20% reviewed f…

### DIFF
--- a/src/app/[locale]/flashcards/components/FlashcardEditor.tsx
+++ b/src/app/[locale]/flashcards/components/FlashcardEditor.tsx
@@ -532,7 +532,7 @@ const FlashcardEditor = ({
 
     const handleSaveGeneratedToThisTopic = async () => {
        if (!topic) return;
-       if (!isContentReady || !dataGenerated) {
+       if (!dataGenerated) {
          toast({ description: 'No data to save', variant: 'destructive' });
          return;
        }

--- a/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
+++ b/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
@@ -16,6 +16,12 @@ import toastHelper from '@/utils/toast.helper';
 import { Button } from '@/components/ui/button';
 import { useTranslations } from 'next-intl';
 
+import { useGenerateFromExisting } from '@/app/[locale]/generate/hooks/useGenerateFromExisting';
+import { handleConvertToQuestionsEdited } from '@/app/[locale]/question/utils/handleConvertToQuestionsEdited';
+import { CONTENT_TYPE_GENERATE, IQuestionsFromSSERaw } from '@/app/[locale]/generate/types';
+import { writeLocalQuiz } from '@/app/[locale]/quiz/utils/localQuiz.storage';
+import { buildPayloadFromLearnedFlashcards } from '@/app/[locale]/question/utils/buildGenPayload';
+
 export type IFlashcardWithReviewPrediction = Pick<
     IFlashcard,
     'flashcardId' | 'front' | 'back' | 'imageUrl' | 'topicName'
@@ -31,6 +37,19 @@ export default function Page() {
     const tCommon = useTranslations('common');
     const tFlashcardLearning = useTranslations('flashcard.learning');
     const { topicId } = params as { topicId: string };
+
+    // initial total when fetched
+    const [initialTotal, setInitialTotal] = useState<number>(0);
+    // List of lessons learned (reviewed)
+    const [studied, setStudied] = useState<IFlashcardWithReviewPrediction[]>([]);
+    // "chunk 20%" completed
+    const [chunksDone, setChunksDone] = useState<number>(0);
+    // preparing quiz for chunk number (to navigate when SSE is done)
+    const [pendingChunk, setPendingChunk] = useState<number | null>(null);
+
+    const { regenerate, sseData, sseStatus, loading } = useGenerateFromExisting();
+
+    const isGenerating = pendingChunk !== null && (loading || sseStatus === 'open');
 
     // Learning tracking integration
     const {
@@ -52,6 +71,42 @@ export default function Page() {
         loading: flashcardsLoading,
         error: flashcardsError,
     } = useFetch<IFlashcardWithReviewPrediction[]>(() => flashcardService.getDueFlashcardsForTopic(topicId));
+
+    useEffect(() => {
+        if (flashcards && flashcards.length > 0) {
+            setInitialTotal(flashcards.length);
+        }
+    }, [flashcards]);
+
+    const chunkSize = Math.max(1, Math.ceil(initialTotal * 0.2)); // luôn >=1
+
+    // Wait for SSE "completed" -> parse -> save local -> redirect to local quiz page
+    useEffect(() => {
+        const raw = (sseData as any)?.data?.data as IQuestionsFromSSERaw | undefined;
+        const payloadStatus = (sseData as any)?.data?.status ?? (sseData as any)?.status;
+
+        // only process while waiting for a specific chunk
+        if (pendingChunk === null) return;
+
+        const isCompleted = sseStatus === 'completed' || payloadStatus === 'completed';
+        if (!isCompleted) return;
+        if (!Array.isArray(raw) || raw.length === 0) return;
+
+        const parsed = handleConvertToQuestionsEdited({
+            type: 'generative',
+            questionsProp: raw,
+        });
+
+        const toStore = parsed.map((q) => ({
+            questionText: q.questionText,
+            choices: q.choices,
+            correctIndex: q.correctIndex,
+        }));
+
+        writeLocalQuiz(topicId, toStore);
+
+        router.push(`/quiz/local?topicId=${topicId}&chunk=${pendingChunk}`);
+    }, [sseStatus, sseData, pendingChunk, topicId, router]);
 
     const currentFlashcard = flashcards ? flashcards[0] : null;
 
@@ -144,10 +199,33 @@ export default function Page() {
             const flashcardsFiltered = flashcards.slice(1);
             setFlashcardsData(flashcardsFiltered);
 
+            const newStudied = [...studied, currentFlashcard];
+            setStudied(newStudied);
+
             // Update learning tracking metrics using context methods
             updateItemsStudied(itemsStudiedCount + 1);
             if (qualityResponse >= 3) {
                 updateCorrectAnswers(correctAnswersCount + 1);
+            }
+
+            // If finish learning the new 20% chunk -> ask gen quiz
+            const studiedCountAfter = newStudied.length;
+            const nextChunk = chunksDone + 1;
+            const nextThreshold = nextChunk * chunkSize;
+            const justReachedNewChunk = studiedCountAfter >= nextThreshold;
+
+            if (justReachedNewChunk && !loading && pendingChunk === null) {
+                const ok = window.confirm('Bạn đã học xong 20% bài. Bạn có muốn làm quiz nhanh không?');
+                if (ok) {
+                    const start = chunksDone * chunkSize;
+                    const end = Math.min(start + chunkSize, studiedCountAfter);
+                    const chunkCards = newStudied.slice(start, end);
+
+                    const payload = buildPayloadFromLearnedFlashcards(topicId, chunkCards);
+                    setPendingChunk(nextChunk);
+                    await regenerate(payload, 'quiz'); // SSE completed sẽ redirect
+                }
+                setChunksDone(nextChunk);
             }
 
             // If this was the last card, save progress to database using context method
@@ -208,16 +286,24 @@ export default function Page() {
     }
 
     return (
-        <FlashcardLearning
-            topicName={currentFlashcard.topicName ? currentFlashcard.topicName : ''}
-            total={flashcards.length}
-            flashcardContainerRef={flashcardContainerRef}
-            cardRef={cardRef}
-            isFrontRef={isFrontRef}
-            flashcard={currentFlashcard}
-            handleManualFlip={handleManualFlip}
-            shouldShowTrackingOptions={shouldShowTrackingOptions}
-            handleOnClickTrackingOption={handleReviewFlashcardClick}
-        />
+        <>
+            <FlashcardLearning
+                topicName={currentFlashcard.topicName ? currentFlashcard.topicName : ''}
+                total={flashcards.length}
+                flashcardContainerRef={flashcardContainerRef}
+                cardRef={cardRef}
+                isFrontRef={isFrontRef}
+                flashcard={currentFlashcard}
+                handleManualFlip={handleManualFlip}
+                shouldShowTrackingOptions={shouldShowTrackingOptions}
+                handleOnClickTrackingOption={handleReviewFlashcardClick}
+            />
+
+            {isGenerating && (
+                <div className="fixed inset-0 z-[60] bg-black/30 backdrop-blur-sm flex items-center justify-center">
+                    <div className="rounded-xl bg-white px-6 py-5 shadow-lg">Generating quiz…</div>
+                </div>
+            )}
+        </>
     );
 }

--- a/src/app/[locale]/question/components/QuestionEditor.tsx
+++ b/src/app/[locale]/question/components/QuestionEditor.tsx
@@ -167,7 +167,7 @@ const QuestionEditor = ({
 
     const handleSaveGeneratedToThisTopic = async () => {
         if (!topic) return;
-        if (!isContentReady || !dataGenerated) {
+        if (!dataGenerated) {
             toast({ description: 'No data to save', variant: 'destructive' });
             return;
         }

--- a/src/app/[locale]/question/utils/buildGenPayload.ts
+++ b/src/app/[locale]/question/utils/buildGenPayload.ts
@@ -1,5 +1,6 @@
 import { IFlashcardWithServer } from '@/app/[locale]/flashcards/components/FlashcardEditor';
 import { IQuestion } from '@/app/[locale]/question/types/question.type';
+import type { IFlashcardWithReviewPrediction } from '@/app/[locale]/flashcards/learning/[topicId]/page';
 
 export const buildContentFromFlashcardsForQuiz = (
   topicId: string | number,
@@ -36,3 +37,15 @@ export const buildContentFromQuestionsForFlashcards = (
     questions: items, // [{ questionText, choices, correctIndex }]
   });
 };
+
+export const buildPayloadFromLearnedFlashcards = (topicId: string | number, cards: IFlashcardWithReviewPrediction[]) => {
+  const items = cards
+    .map(c => ({ q: (c.front ?? '').trim(), a: (c.back ?? '').trim() }))
+    .filter(x => x.q && x.a);
+
+  return JSON.stringify({
+    source: 'FLASH_CARD',
+    topicId,
+    flashcards: items, // [{ q, a }]
+  });
+}

--- a/src/app/[locale]/quiz/local/page.tsx
+++ b/src/app/[locale]/quiz/local/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { readLocalQuiz, clearLocalQuiz, LocalQuizQuestion } from '../utils/localQuiz.storage';
+import QuizQuestion from '@/app/[locale]/quiz/components/QuizQuestion'; 
+import { Button } from '@/components/ui/button';
+
+type LocalQuestion = LocalQuizQuestion & { selectedAnswer?: number | null };
+
+export default function LocalQuizPage() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const topicId = search.get('topicId');
+  const chunk = search.get('chunk'); // NEW
+
+  const [questions, setQuestions] = useState<LocalQuestion[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    if (!topicId) return;
+    const data = readLocalQuiz(topicId);
+    if (!data || data.length === 0) {
+      // No data -> back to study
+      router.replace(`/flashcards/learning/${topicId}`);
+      return;
+    }
+    setQuestions(data.map(q => ({ ...q, selectedAnswer: null })));
+  }, [topicId, router]); // add router
+
+  const total = questions.length;
+
+  const answeredCount = useMemo(
+    () => questions.filter(q => typeof q.selectedAnswer === 'number').length,
+    [questions]
+  );
+
+  const handleSubmit = () => {
+    const correct = questions.reduce((acc, q) => acc + (q.selectedAnswer === q.correctIndex ? 1 : 0), 0);
+    setScore(correct);
+    setSubmitted(true);
+  };
+
+  const handleExit = () => {
+    if (topicId) clearLocalQuiz(topicId);
+    router.replace(`/flashcards/learning/${topicId}`);
+  };
+
+  if (!topicId) return <div>Missing topicId</div>;
+  if (!questions || questions.length === 0) return <div>Loading…</div>;
+
+  return (
+    <div className="px-6 py-8 max-w-5xl mx-auto">
+      <h2 className="text-2xl font-semibold mb-4">
+        Quick Quiz {chunk ? `(chunk ${chunk})` : ''}
+      </h2>
+
+      {!submitted ? (
+        <>
+          <div className="space-y-4">
+            {questions.map((q, idx) => (
+              <QuizQuestion
+                key={idx}
+                questionNumber={idx + 1}
+                questionText={q.questionText}
+                choices={q.choices}
+                onAnswerSelect={(sel) => {
+                  const next = [...questions];
+                  next[idx].selectedAnswer = sel;
+                  setQuestions(next);
+                }}
+              />
+            ))}
+          </div>
+          <Button className="mt-6" onClick={handleSubmit} disabled={answeredCount === 0}>
+            Submit
+          </Button>
+        </>
+      ) : (
+        <>
+          <div className="mb-6">
+            <div className="text-xl font-medium">
+              Result: {score}/{total} correct
+            </div>
+            <div className="text-sm text-muted-foreground">
+              Review below (green = correct, red = your wrong answer).
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            {questions.map((q, idx) => (
+              <div key={idx} className="bg-background p-6 rounded-lg border">
+                <div className="font-semibold mb-3">Question {idx + 1}: {q.questionText}</div>
+                <div className="space-y-2">
+                  {q.choices.map((choice, cIdx) => {
+                    if (choice == null || choice.trim() === '') return null;
+                    const isCorrect = cIdx === q.correctIndex;
+                    const isSelected = cIdx === q.selectedAnswer;
+                    const style =
+                      isCorrect ? 'border-green-500 bg-green-50'
+                      : (isSelected ? 'border-red-500 bg-red-50' : 'border-transparent');
+
+                    return (
+                      <div key={cIdx} className={`px-3 py-2 rounded border ${style}`}>
+                        {choice}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6 flex gap-3">
+            <Button variant="outline" onClick={handleExit}>Done</Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/quiz/utils/localQuiz.storage.ts
+++ b/src/app/[locale]/quiz/utils/localQuiz.storage.ts
@@ -1,0 +1,25 @@
+export type LocalQuizQuestion = {
+  questionText: string;
+  choices: string[];
+  correctIndex: number;
+};
+
+const keyForTopic = (topicId: string | number) => `localQuiz:${topicId}`;
+
+export function writeLocalQuiz(topicId: string | number, questions: LocalQuizQuestion[]) {
+  localStorage.setItem(keyForTopic(topicId), JSON.stringify(questions));
+}
+
+export function readLocalQuiz(topicId: string | number): LocalQuizQuestion[] | null {
+  const raw = typeof window !== 'undefined' ? localStorage.getItem(keyForTopic(topicId)) : null;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as LocalQuizQuestion[];
+  } catch {
+    return null;
+  }
+}
+
+export function clearLocalQuiz(topicId: string | number) {
+  localStorage.removeItem(keyForTopic(topicId));
+}


### PR DESCRIPTION
Add “Quick Local Quiz” feature in Flashcards learning screen: every time the user finishes reviewing 20% ​​of the total flashcards of the current learning session, the system will ask if they want to take a quick quiz. If they agree, FE calls GenAI to create a quiz from the cards they just learned, temporarily save it to localStorage, switch to the local quiz page, finish viewing the results and exiting, then delete the local data and return to continue learning. Users who decline are still considered to have reviewed normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced “Quick Quiz” during learning: after each 20% of cards, optionally generate a short quiz and show a full-screen “Generating quiz…” overlay.
  - Added a local quiz page: answer questions, submit to get score, review with correct/incorrect highlights, and exit back to learning.
  - Quizzes persist per topic in local storage and are cleared on exit.
  - Enabled saving generated content to a topic when data is available, without requiring content readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->