### PR TITLE
refactor/home: update max width for current learning process card

### DIFF
--- a/src/app/[locale]/home/components/CurrentProcessLearning.tsx
+++ b/src/app/[locale]/home/components/CurrentProcessLearning.tsx
@@ -93,7 +93,7 @@ const CurrentProcessLearning: React.FC<CurrentProcessLearningProps> = ({}) => {
 
     if (loading) {
         return (
-            <Card className="max-w-[600px] min-w-[40%] h-[200px] mx-auto mt-2 mb-8 bg-slate-500 dark:bg-gray-700 border-0 shadow-xl">
+            <Card className="max-w-[400px] min-w-[40%] h-[200px] mx-auto mt-2 mb-8 bg-slate-500 dark:bg-gray-700 border-0 shadow-xl">
                 <CardHeader className="pb-3">
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
@@ -126,7 +126,7 @@ const CurrentProcessLearning: React.FC<CurrentProcessLearningProps> = ({}) => {
     }
 
     return (
-        <Card className="max-w-[600px] min-w-[40%] mx-auto mt-2 mb-8 rounded-3xl bg-gradient-to-r from-white/80 via-white/60 to-white/80 dark:from-slate-800/70 dark:via-slate-900/40 dark:to-slate-800/70 backdrop-blur-md shadow-[0_12px_50px_-12px_rgba(0,0,0,0.25)] dark:shadow-[0_8px_40px_-10px_rgba(0,0,0,0.6)] border-0 shadow-xl">
+        <Card className="max-w-[200px] min-w-[40%] mx-auto mt-2 mb-8 rounded-3xl bg-gradient-to-r from-white/80 via-white/60 to-white/80 dark:from-slate-800/70 dark:via-slate-900/40 dark:to-slate-800/70 backdrop-blur-md shadow-[0_12px_50px_-12px_rgba(0,0,0,0.25)] dark:shadow-[0_8px_40px_-10px_rgba(0,0,0,0.6)] border-0 shadow-xl">
             <CardHeader className="pb-3">
                 {data ? (
                     <div className="flex items-center justify-between">

--- a/src/app/[locale]/topics/components/common/TopicCard.tsx
+++ b/src/app/[locale]/topics/components/common/TopicCard.tsx
@@ -58,7 +58,15 @@ export default function TopicCard({ topic, handleNameClick, menuContent, footer 
                     <div className="flex justify-between items-start">
                         <div className="flex-1 min-w-0">
                             <CardTitle
+                                role="button"
+                                tabIndex={0}
                                 onClick={() => handleNameClick(topic)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        handleNameClick(topic);
+                                    }
+                                }}
                                 className="text-base font-semibold tracking-tight leading-snug line-clamp-2 bg-gradient-to-r from-indigo-600 via-sky-600 to-cyan-600 dark:from-indigo-200 dark:via-sky-200 dark:to-cyan-200 bg-clip-text text-transparent cursor-pointer hover:from-indigo-500 hover:via-sky-500 hover:to-cyan-500 dark:hover:from-indigo-300 dark:hover:via-sky-300 dark:hover:to-cyan-300 transition-colors"
                             >
                                 {name}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Made the Current Process Learning cards more compact for a cleaner layout: loading state max width reduced from 600px to 400px, and loaded state width reduced from 600px to 200px.
  * Visual-only update; no changes to content, skeleton placeholders, or navigation behavior.
  * No impact on public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->