### PR TITLE
feat(generate): re open method mind map for all type

### DIFF
--- a/src/app/[locale]/generate/components/steps/SelectMethod.tsx
+++ b/src/app/[locale]/generate/components/steps/SelectMethod.tsx
@@ -46,11 +46,15 @@ const SelectMethod: React.FC<SelectMethodProps> = () => {
     };
 
     const suggestMethodSelection = useMemo(() => {
-        if (importMethod === 'file') {
-            return suggestedMethods;
-        }
-        // Exclude mindmap if importMethod is not 'file'
-        return suggestedMethods.filter((method) => method !== 'mindmap');
+        // if (importMethod === 'file') {
+        //     return suggestedMethods;
+        // }
+        // // Exclude mindmap if importMethod is not 'file'
+        // return suggestedMethods.filter((method) => method !== 'mindmap');
+
+        //NOTE: Revert for generate roadmap for all type content
+        //TODO: check for filter specific method need generate roadmap
+        return suggestedMethods;
     }, [selectedMethod]);
 
     return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - All import methods now display the full set of generation methods.
  - The Mindmap option is available across all content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->