### PR TITLE
feature/pomodoro: implement v2 for pomodoro components

### DIFF
--- a/messages/en/common.json
+++ b/messages/en/common.json
@@ -68,7 +68,6 @@
             "readSuccess": "{name} loaded successfully",
             "updateSuccess": "Update {name} successfully",
             "deleteSuccess": "Delete {name} successfully",
-
             "createError": "Failed to create {name}",
             "readError": "Failed to load {name}",
             "updateError": "Failed to update {name}",

--- a/messages/en/common.json
+++ b/messages/en/common.json
@@ -72,7 +72,9 @@
             "createError": "Failed to create {name}",
             "readError": "Failed to load {name}",
             "updateError": "Failed to update {name}",
-            "deleteError": "Failed to delete {name}"
+            "deleteError": "Failed to delete {name}",
+            "fillNumberError": " Please enter numeric",
+            "fillNumberPositiveError": " Please enter positive number"
         },
         "labels": {
             "name": "Name",

--- a/messages/en/flashcard.json
+++ b/messages/en/flashcard.json
@@ -30,7 +30,8 @@
             "showAnswer": "Show answer",
             "flashcardsRemaining": "flashcards remaining",
             "greatJob": "Great job! 🎉",
-            "flashcardsCompleted": "You've completed all the flashcards for this topic. There's nothing more to learn right now."
+            "flashcardsCompleted": "You've completed all the flashcards for this topic. There's nothing more to learn right now.",
+            "flashcardsEmpty": "There are no flashcards for this topic! Try creating a flashcard set."
         },
         "import": {
             "title": "Import your data",

--- a/messages/en/pomodoro.json
+++ b/messages/en/pomodoro.json
@@ -1,0 +1,35 @@
+{
+    "pomodoro": {
+        "title": "Pomodoro",
+        "ambient": {
+            "panelTitle": "Ambient Sounds",
+            "panelTitleBreak": "Ambient Sounds (Break)",
+            "noSounds": "No sounds added.",
+            "soundAdded": "Sound already added",
+            "notFound": "Audio not found in storage",
+            "loadFailed": "Failed to load audio from storage",
+            "uploadFailed": "Upload failed",
+            "indexedDbFallback": "IndexedDB store failed; falling back to base64.",
+            "tooLarge": "File too large. Max {max}MB"
+        },
+        "timer": {
+            "resetTimer": "Reset Timer",
+            "resetStopwatch": "Reset Stopwatch",
+            "skip": "Skip",
+            "breakTime": "Break Time",
+            "secSuffix": "sec",
+            "hrLabel": "hr",
+            "minLabel": "min",
+            "setTimeToast": "Please set your time session"
+        },
+        "settings": {
+            "title": "Settings",
+            "version": "v1",
+            "volume": "Volume",
+            "playDuringBreak": "Play during break",
+            "distinctBreakAmbient": "Distinct break ambient",
+            "distinctHelp": "Select different sound during break via sound panel.",
+            "resetDefaults": "Reset Defaults"
+        }
+    }
+}

--- a/messages/vi/common.json
+++ b/messages/vi/common.json
@@ -73,7 +73,10 @@
             "createError": "Không thể tạo {name}",
             "readError": "Không thể tải {name}",
             "updateError": "Không thể cập nhật {name}",
-            "deleteError": "Không thể xóa {name}"
+            "deleteError": "Không thể xóa {name}",
+
+            "fillNumberError": "Chỉ nhập số",
+            "fillNumberPositiveError": "Vui lòng nhập số dương"
         },
         "labels": {
             "name": "Tên",

--- a/messages/vi/common.json
+++ b/messages/vi/common.json
@@ -69,12 +69,10 @@
             "readSuccess": "Tải {name} thành công",
             "updateSuccess": "Cập nhật {name} thành công",
             "deleteSuccess": "Xóa {name} thành công",
-
             "createError": "Không thể tạo {name}",
             "readError": "Không thể tải {name}",
             "updateError": "Không thể cập nhật {name}",
             "deleteError": "Không thể xóa {name}",
-
             "fillNumberError": "Chỉ nhập số",
             "fillNumberPositiveError": "Vui lòng nhập số dương"
         },

--- a/messages/vi/flashcard.json
+++ b/messages/vi/flashcard.json
@@ -30,7 +30,8 @@
             "showAnswer": "Hiện kết quả",
             "flashcardsRemaining": "flashcards còn lại",
             "greatJob": "Làm tốt lắm! 🎉",
-            "flashcardsCompleted": "Bạn đã hoàn thành tất cả flashcard cho chủ đề này. Hiện tại không còn gì để học thêm."
+            "flashcardsCompleted": "Bạn đã hoàn thành tất cả flashcard cho chủ đề này. Hiện tại không còn gì để học thêm.",
+            "flashcardsEmpty": "Không có flashcard nào cho topic này! Bạn hãy thử tạo bộ flashcard"
         },
         "import": {
             "title": "Nhập dữ liệu của bạn",

--- a/messages/vi/pomodoro.json
+++ b/messages/vi/pomodoro.json
@@ -1,0 +1,35 @@
+{
+    "pomodoro": {
+        "title": "Pomodoro",
+        "ambient": {
+            "panelTitle": "Âm thanh nền",
+            "panelTitleBreak": "Âm thanh nền (Nghỉ)",
+            "noSounds": "Chưa có âm thanh nào.",
+            "soundAdded": "Âm thanh đã tồn tại",
+            "notFound": "Không tìm thấy âm thanh trong bộ nhớ",
+            "loadFailed": "Tải âm thanh thất bại",
+            "uploadFailed": "Tải lên thất bại",
+            "indexedDbFallback": "Lưu IndexedDB thất bại; chuyển sang base64.",
+            "tooLarge": "Tệp quá lớn. Tối đa {max}MB"
+        },
+        "timer": {
+            "resetTimer": "Đặt lại hẹn giờ",
+            "resetStopwatch": "Đặt lại bấm giờ",
+            "skip": "Bỏ qua",
+            "breakTime": "Thời gian nghỉ",
+            "secSuffix": "giây",
+            "hrLabel": "giờ",
+            "minLabel": "phút",
+            "setTimeToast": "Vui lòng đặt phiên thời gian "
+        },
+        "settings": {
+            "title": "Cài đặt",
+            "version": "v1",
+            "volume": "Âm lượng",
+            "playDuringBreak": "Phát khi nghỉ",
+            "distinctBreakAmbient": "Âm thanh nghỉ riêng",
+            "distinctHelp": "Chọn âm thanh khác khi nghỉ trong bảng âm thanh.",
+            "resetDefaults": "Khôi phục mặc định"
+        }
+    }
+}

--- a/src/app/[locale]/flashcards/browse/[topicId]/page.tsx
+++ b/src/app/[locale]/flashcards/browse/[topicId]/page.tsx
@@ -16,6 +16,7 @@ import flashcardService from '@/services/flashcard/flashcard.service';
 import toastHelper from '@/utils/toast.helper';
 import { cn } from '@/lib/utils';
 import Pomodoro from '@/components/pomodoro/Pomodoro';
+import useActivePomodoro from '@/hooks/useActivePomodoro';
 
 const initialAutoPlaySpeed = 3;
 
@@ -83,6 +84,8 @@ export default function Page() {
     const [isImagesModalOpen, setIsImagesModalOpen] = useState<boolean>(false);
 
     const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
+
+    useActivePomodoro();
 
     useEffect(() => {
         function handleKeyDown(event: KeyboardEvent) {
@@ -369,8 +372,6 @@ export default function Page() {
                         isSidebarOpen ? 'w-[75%]' : 'w-full',
                     )}
                 >
-                    <Pomodoro position="top-right" positionX={-200} />
-
                     <div className="absolute top-8 right-8 z-20">
                         <Button size="icon" variant="outline" onClick={handleSidebarOpenToogle}>
                             <PanelLeft size={18} />

--- a/src/app/[locale]/flashcards/browse/[topicId]/page.tsx
+++ b/src/app/[locale]/flashcards/browse/[topicId]/page.tsx
@@ -49,6 +49,7 @@ function getFlashcardsShuffled(flashcards: IFlashcard[]): IFlashcard[] {
 
 export default function Page() {
     const t = useTranslations('flashcard.study');
+    const tFlashcardLearning = useTranslations('flashcard.learning');
     const router = useRouter();
     const params = useParams();
     if (!params?.topicId) return <div>No topic id is provided</div>;
@@ -86,6 +87,10 @@ export default function Page() {
     const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
 
     useActivePomodoro();
+
+    function handleBackClick() {
+        router.back();
+    }
 
     useEffect(() => {
         function handleKeyDown(event: KeyboardEvent) {
@@ -326,9 +331,32 @@ export default function Page() {
     if (flashcardsLoading === true || flashcards === null || flashcards === undefined) {
         return <div>Loading flashcards...</div>;
     }
-
     if (flashcards.length === 0 || !currentFlashcard) {
-        return <div>No Flashcards to study</div>;
+        return (
+            <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+                <div className="text-center space-y-4">
+                    <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center border border-gray-200">
+                        <svg className="w-8 h-8 text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                            />
+                        </svg>
+                    </div>
+                    <p className="text-gray-700 max-w-md">{tFlashcardLearning('flashcardsEmpty')}</p>
+                    <div className="pt-4">
+                        <Button
+                            onClick={handleBackClick}
+                            className="px-6 py-2  rounded-lg hover:bg-muted-foreground transition-colors border border-gray-300"
+                        >
+                            Go Back
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        );
     }
 
     function renderFlashcardButtonsSection(style: string) {

--- a/src/app/[locale]/flashcards/learning/components/FlashcardLearning.tsx
+++ b/src/app/[locale]/flashcards/learning/components/FlashcardLearning.tsx
@@ -12,7 +12,7 @@ import { IFlashcardStatusCounts, IFlashcardWithReviewPrediction } from '../[topi
 import { useLearningOptions } from '../hooks/useLearningOptions';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import flashcardHelper from '@/utils/flashcard/flashcard.helper';
-import Pomodoro from '@/components/pomodoro/Pomodoro';
+import useActivePomodoro from '@/hooks/useActivePomodoro';
 
 // type TrackingOption = {
 //     icon: any;
@@ -49,6 +49,8 @@ export function FlashcardLearning({
     const tFlashcard = useTranslations('flashcard.learning');
 
     const learningOptions = useLearningOptions();
+
+    useActivePomodoro();
 
     // const trackingOptions: TrackingOption[] = [
     //     { icon: <Angry size={24} fill="red" />, label: flashcardT('responseOptions.blackout'), qualityResponse: 0 },
@@ -92,7 +94,6 @@ export function FlashcardLearning({
     return (
         <div className="flex bg-gray-background w-full h-full">
             <div className="relative flex-1 p-5 overflow-hidden">
-                <Pomodoro position="top-center" positionX={-10} positionY={-70} />
                 <div className="relative bg-gray-100 dark:bg-gray-850 flex flex-col h-full items-center justify-center rounded-lg">
                     <Flashcard
                         style={`flex w-[55%] mt-2 ${shouldShowTrackingOptions ? 'h-[70%]' : 'h-[80%]'}`}

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -100,6 +100,7 @@ export default function Pomodoro({
     className,
 }: IPropPomodoro) {
     const tCommon = useTranslations('common');
+    const tPomodoro = useTranslations('pomodoro');
     const [mode, toggleMode] = useToggle<TypeMode>(defaultMode);
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const [isActive, setIsActive] = useState<boolean>(false);
@@ -231,7 +232,7 @@ export default function Pomodoro({
 
     const validateTimer = () => {
         if (countTimer <= 0) {
-            toast({ description: 'Please set your time session' });
+            toast({ description: tPomodoro('timer.setTimeToast') });
             return false;
         }
         return true;
@@ -261,7 +262,7 @@ export default function Pomodoro({
         } else {
             // Session pomodoro
             toast({
-                description: 'Break Time',
+                description: tPomodoro('timer.breakTime'),
             });
             setIsBreakTime(true);
             setCountTimer(breakTime * 60);
@@ -458,11 +459,11 @@ export default function Pomodoro({
                         idbObjectUrlRef.current = objUrl;
                         src = objUrl;
                     } else {
-                        toast({ description: 'Audio not found in storage' });
+                        toast({ description: tPomodoro('ambient.notFound') });
                         return;
                     }
                 } catch {
-                    toast({ description: 'Failed to load audio from storage' });
+                    toast({ description: tPomodoro('ambient.loadFailed') });
                     return;
                 }
             }
@@ -540,11 +541,11 @@ export default function Pomodoro({
         const id = `${file.name}-${file.size}-${Date.now()}`;
         // Prevent duplicates by name+size
         if (ambientSounds.some((s) => s.id.startsWith(file.name) && !s.builtin)) {
-            toast({ description: 'Sound already added' });
+            toast({ description: tPomodoro('ambient.soundAdded') });
         }
         const sizeMB = file.size / (1024 * 1024);
         if (sizeMB > MAX_CUSTOM_SOUND_SIZE_MB) {
-            toast({ description: `File too large. Max ${MAX_CUSTOM_SOUND_SIZE_MB}MB` });
+            toast({ description: tPomodoro('ambient.tooLarge', { max: MAX_CUSTOM_SOUND_SIZE_MB }) });
             e.target.value = '';
             return;
         }
@@ -555,7 +556,7 @@ export default function Pomodoro({
                 await idbPutAudio(id, baseName, file);
                 src = `indexeddb:${id}`;
             } catch {
-                toast({ description: 'IndexedDB store failed; falling back to base64.' });
+                toast({ description: tPomodoro('ambient.indexedDbFallback') });
             }
         }
         if (!src) {
@@ -567,7 +568,7 @@ export default function Pomodoro({
                     customBlobUrlsRef.current.push(url);
                     src = url;
                 } catch {
-                    toast({ description: 'Upload failed' });
+                    toast({ description: tPomodoro('ambient.uploadFailed') });
                     e.target.value = '';
                     return;
                 }
@@ -646,7 +647,9 @@ export default function Pomodoro({
                 <Card className="p-2 rounded-lg border dark:border-white/10 dark:bg-slate-900/95 backdrop-blur">
                     <div className="flex items-center justify-between mb-1 px-1">
                         <span className="text-xs font-semibold text-slate-300">
-                            Ambient Sounds {isBreakTime && breakSpecificEnabled && '(Break)'}
+                            {isBreakTime && breakSpecificEnabled
+                                ? tPomodoro('ambient.panelTitleBreak')
+                                : tPomodoro('ambient.panelTitle')}
                         </span>
                         <button
                             onClick={() => fileInputRef.current?.click()}
@@ -706,7 +709,7 @@ export default function Pomodoro({
                             );
                         })}
                         {ambientSounds.length === 0 && (
-                            <div className="text-[10px] text-slate-400 px-2 py-2">No sounds added.</div>
+                            <div className="text-[10px] text-slate-400 px-2 py-2">{tPomodoro('ambient.noSounds')}</div>
                         )}
                     </div>
                 </Card>
@@ -727,12 +730,12 @@ export default function Pomodoro({
             >
                 <Card className="p-3 rounded-lg border dark:border-white/10 dark:bg-slate-900/95 backdrop-blur space-y-3">
                     <div className="flex items-center justify-between text-xs">
-                        <span className="text-slate-300 font-semibold">Settings</span>
-                        <span className="text-[10px] text-slate-500">v1</span>
+                        <span className="text-slate-300 font-semibold">{tPomodoro('settings.title')}</span>
+                        <span className="text-[10px] text-slate-500">{tPomodoro('settings.version')}</span>
                     </div>
                     <div className="space-y-1">
                         <div className="flex items-center justify-between text-[11px] text-slate-300">
-                            <span>Volume</span>
+                            <span>{tPomodoro('settings.volume')}</span>
                             <span>{Math.round(volume * 100)}%</span>
                         </div>
                         <input
@@ -753,7 +756,7 @@ export default function Pomodoro({
                             onChange={(e) => setPlayDuringBreakVal(e.target.checked)}
                             className="accent-amber-400"
                         />
-                        <span>Play during break</span>
+                        <span>{tPomodoro('settings.playDuringBreak')}</span>
                     </label>
                     <label className="flex items-center gap-2 text-[11px] text-slate-300 cursor-pointer select-none">
                         <input
@@ -762,12 +765,10 @@ export default function Pomodoro({
                             onChange={(e) => setBreakSpecificEnabled(e.target.checked)}
                             className="accent-amber-400"
                         />
-                        <span>Distinct break ambient</span>
+                        <span>{tPomodoro('settings.distinctBreakAmbient')}</span>
                     </label>
                     {breakSpecificEnabled && (
-                        <div className="text-[11px] text-slate-400">
-                            Select different sound during break via sound panel.
-                        </div>
+                        <div className="text-[11px] text-slate-400">{tPomodoro('settings.distinctHelp')}</div>
                     )}
                     <button
                         onClick={() => {
@@ -780,7 +781,7 @@ export default function Pomodoro({
                         }}
                         className="w-full text-[11px] mt-1 rounded-md bg-slate-800/60 hover:bg-slate-700/60 py-1 text-slate-300 hover:text-white"
                     >
-                        Reset Defaults
+                        {tPomodoro('settings.resetDefaults')}
                     </button>
                 </Card>
             </motion.div>
@@ -891,7 +892,7 @@ export default function Pomodoro({
                     </div>
 
                     <div className="mt-1 text-center font-semibold text-sm text-[10px] text-slate-400">
-                        {pad2(seconds)} sec
+                        {pad2(seconds)} {tPomodoro('timer.secSuffix')}
                     </div>
                 </>
             );
@@ -900,11 +901,11 @@ export default function Pomodoro({
             <div className="mt-3 grid grid-cols-2 gap-2 text-center">
                 <div className="rounded-md border dark:border-white/10 dark:bg-slate-800/60 py-2">
                     <div className="text-2xl font-semibold tracking-tight">{pad2(minutes)}</div>
-                    <div className="text-[10px] uppercase text-slate-400">min</div>
+                    <div className="text-[10px] uppercase text-slate-400">{tPomodoro('timer.minLabel')}</div>
                 </div>
                 <div className="rounded-md border dark:border-white/10 dark:bg-slate-800/60 py-2">
                     <div className="text-2xl font-semibold tracking-tight">{pad2(seconds)}</div>
-                    <div className="text-[10px] uppercase text-slate-400">sec</div>
+                    <div className="text-[10px] uppercase text-slate-400">{tPomodoro('timer.secSuffix')}</div>
                 </div>
             </div>
         );
@@ -919,7 +920,7 @@ export default function Pomodoro({
                     aria-label="Reset"
                 >
                     <RotateCcw className="h-3.5 w-3.5" />
-                    {isCountdown ? 'Reset Timer' : 'Reset Stopwatch'}
+                    {isCountdown ? tPomodoro('timer.resetTimer') : tPomodoro('timer.resetStopwatch')}
                 </button>
             );
 
@@ -930,7 +931,7 @@ export default function Pomodoro({
                 aria-label="Skip"
             >
                 <LucideSkipForward className="h-3.5 w-3.5" />
-                Skip
+                {tPomodoro('timer.skip')}
             </button>
         );
     };

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -537,12 +537,17 @@ export default function Pomodoro({
     const handleUploadSound = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = e.target.files;
         if (!files || !files.length) return;
+
         const file = files[0];
-        const id = `${file.name}-${file.size}-${Date.now()}`;
+        const id = `${file.name}-${file.size}`; // stable id for dedup
         // Prevent duplicates by name+size
-        if (ambientSounds.some((s) => s.id.startsWith(file.name) && !s.builtin)) {
+
+        if (ambientSoundsLS?.some((s) => s.id === id && !s.builtin)) {
             toast({ description: tPomodoro('ambient.soundAdded') });
+            e.target.value = '';
+            return;
         }
+
         const sizeMB = file.size / (1024 * 1024);
         if (sizeMB > MAX_CUSTOM_SOUND_SIZE_MB) {
             toast({ description: tPomodoro('ambient.tooLarge', { max: MAX_CUSTOM_SOUND_SIZE_MB }) });
@@ -561,6 +566,7 @@ export default function Pomodoro({
         }
         if (!src) {
             try {
+                // For small files only; larger go to IDB above
                 src = await fileToDataUrl(file);
             } catch {
                 try {

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -1,12 +1,15 @@
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import { Card } from '../ui/card';
-import { useEffect, useMemo, useState } from 'react';
+import { InputHTMLAttributes, useEffect, useMemo, useRef, useState } from 'react';
 import { useInterval } from '@/hooks/useInterval';
 import { Button } from '../ui/button';
 import useToggle from '@/hooks/useToggle';
 import { Clock, Timer, Play, Pause, RotateCcw, LucideSkipForward } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { toast } from '@/hooks/use-toast';
+import { Input } from '../ui/input';
+import { isNegative, isNumber, isPositiveNumber } from '@/utils/validators';
+import { useTranslations } from 'next-intl';
 
 export type TypePosition = 'top-center' | 'bottom-center' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 export type TypeMode = 'countdown' | 'stopwatch';
@@ -19,6 +22,8 @@ export interface IPropPomodoro {
     breakTime?: number; // minutes for countdown
     className?: string;
 }
+
+type TypeEditTimer = 'minute' | 'hour';
 
 const DEFAULT_MINUTE_COUNT_DOWN = 45; // minutes
 const DEFAULT_MINUTE_BREAK_TIME_COUNT_DOWN = 5; // minutes
@@ -78,6 +83,7 @@ export default function Pomodoro({
     breakTime = DEFAULT_MINUTE_BREAK_TIME_COUNT_DOWN,
     className,
 }: IPropPomodoro) {
+    const tCommon = useTranslations('common');
     const [mode, toggleMode] = useToggle<TypeMode>(defaultMode);
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const [isActive, setIsActive] = useState<boolean>(false);
@@ -87,11 +93,25 @@ export default function Pomodoro({
     const initialSeconds = useMemo(() => (defaultMode === 'countdown' ? times * 60 : 0), [defaultMode, times]);
     const [countTimer, setCountTimer] = useState<number>(initialSeconds);
 
-    useEffect(() => {
-        setCountTimer(defaultMode === 'countdown' ? times * 60 : 0);
+    const minuteEditRef = useRef<HTMLDivElement>(null);
+    const hourEditRef = useRef<HTMLDivElement>(null);
+
+    const [editTimer, setEditTimer] = useState<{
+        minute: boolean;
+        hour: boolean;
+    }>({
+        minute: false,
+        hour: false,
+    });
+
+    const handleClickEditTimer = (type: TypeEditTimer) => {
         setIsActive(false);
-        setIsPause(false);
-    }, [defaultMode, times]);
+
+        setEditTimer({
+            minute: type === 'minute',
+            hour: type === 'hour',
+        });
+    };
 
     const reset = () => {
         setIsActive(false);
@@ -141,6 +161,12 @@ export default function Pomodoro({
             setIsOpen(true);
         }
     };
+
+    useEffect(() => {
+        setCountTimer(defaultMode === 'countdown' ? times * 60 : 0);
+        setIsActive(false);
+        setIsPause(false);
+    }, [defaultMode, times]);
 
     useInterval(() => {
         if (!isActive || isPause) return;
@@ -229,19 +255,93 @@ export default function Pomodoro({
         );
     };
 
+    const handleOnChangeTimer = (type: TypeEditTimer, value: string) => {
+        console.log(value);
+
+        if (!isNumber(value)) {
+            return toast({ description: tCommon('messages.fillNumberError') });
+        }
+
+        if (isNegative(value)) {
+            return toast({ description: tCommon('messages.fillNumberPositiveError') });
+        }
+
+        const time = parseFloat(value);
+
+        const seconds = type === 'minute' ? time * 60 : time * 60 * 60;
+
+        setCountTimer(seconds);
+    };
+
+    // Close edit mode when clicking outside
+    useEffect(() => {
+        if (!editTimer.minute && !editTimer.hour) return;
+
+        const handleClickOutside = (e: MouseEvent | TouchEvent) => {
+            const target = e.target as Node;
+            const minuteEl = minuteEditRef.current;
+            const hourEl = hourEditRef.current;
+
+            if (minuteEl && minuteEl.contains(target)) return;
+            if (hourEl && hourEl.contains(target)) return;
+
+            setEditTimer({ minute: false, hour: false });
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('touchstart', handleClickOutside);
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('touchstart', handleClickOutside);
+        };
+    }, [editTimer.minute, editTimer.hour]);
+
+    const renderStatusTimer = (type: TypeEditTimer) => {
+        const prefix = type == 'hour' ? 'hr' : 'min';
+        const times = type == 'hour' ? pad2(hours) : pad2(minutes);
+
+        const renderEditMode = () => {
+            if (editTimer[type])
+                return (
+                    <Input
+                        autoFocus
+                        value={times}
+                        onChange={(e) => handleOnChangeTimer(type, e.target.value)}
+                        onBlur={() => setEditTimer((prev) => ({ ...prev, [type]: false }))}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                                e.preventDefault();
+                                (e.target as HTMLInputElement).blur(); // triggers onBlur to close edit mode
+                            } else if (e.key === 'Escape') {
+                                e.preventDefault();
+                                setEditTimer((prev) => ({ ...prev, [type]: false }));
+                            }
+                        }}
+                    />
+                );
+            return times;
+        };
+
+        return (
+            <div
+                ref={type == 'minute' ? minuteEditRef : hourEditRef}
+                onClick={() => handleClickEditTimer(type)}
+                className="rounded-md border dark:border-white/10 dark:bg-slate-800/60 py-2"
+            >
+                <div className="text-2xl font-semibold tracking-tight">{renderEditMode()}</div>
+                <div className="text-[10px] uppercase text-slate-400">{prefix}</div>
+            </div>
+        );
+    };
+
     const renderTimer = () => {
         if (!isBreakTime)
             return (
                 <>
                     <div className="mt-3 grid grid-cols-2 gap-2 text-center">
-                        <div className="rounded-md border dark:border-white/10 dark:bg-slate-800/60 py-2">
-                            <div className="text-2xl font-semibold tracking-tight">{pad2(hours)}</div>
-                            <div className="text-[10px] uppercase text-slate-400">hr</div>
-                        </div>
-                        <div className="rounded-md border dark:border-white/10 dark:bg-slate-800/60 py-2">
-                            <div className="text-2xl font-semibold tracking-tight">{pad2(minutes)}</div>
-                            <div className="text-[10px] uppercase text-slate-400">min</div>
-                        </div>
+                        {renderStatusTimer('hour')}
+                        {renderStatusTimer('minute')}
                     </div>
 
                     <div className="mt-1 text-center font-semibold text-sm text-[10px] text-slate-400">

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -367,13 +367,15 @@ export default function Pomodoro({
         if (isNegative(value)) {
             return toast({ description: tCommon('messages.fillNumberPositiveError') });
         }
+        const units = parseInt(value, 10);
+        const safeUnits = isNaN(units) ? 0 : Math.max(0, units);
+        const newHours = type === 'hour' ? safeUnits : hours;
+        const newMinutes = type === 'minute' ? safeUnits : minutes;
 
-        const minute = parseFloat(value);
+        const totalSeconds = newHours * 3600 + newMinutes * 60;
 
-        const seconds = type === 'minute' ? minute * 60 : minute * 60 * 60;
-
-        setCountTimer(seconds);
-        setTimerDefaultCount(minute);
+        setCountTimer(totalSeconds);
+        setTimerDefaultCount(newHours * 60 + newMinutes);
         setHasWarnedFiveSec(false);
     };
 

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -159,7 +159,7 @@ export default function Pomodoro({
     const fileInputRef = useRef<HTMLInputElement | null>(null);
 
     const initialSeconds = useMemo(() => (defaultMode === 'countdown' ? times * 60 : 0), [defaultMode, times]);
-    const [countTimer, setCountTimer] = useState<number>(initialSeconds);
+    const [countTimer, setCountTimer] = useState<number>(10);
 
     const minuteEditRef = useRef<HTMLDivElement>(null);
     const hourEditRef = useRef<HTMLDivElement>(null);
@@ -171,6 +171,8 @@ export default function Pomodoro({
         minute: false,
         hour: false,
     });
+
+    //---------- Timer edition logic ---------- //
 
     const handleClickEditTimer = (type: TypeEditTimer) => {
         setIsActive(false);
@@ -263,12 +265,14 @@ export default function Pomodoro({
         }
     }, DEFAULT_TIME_SUB_COUNT_DOWN);
 
+    //---------- Render times ---------- //
     const hours = Math.floor(countTimer / 3600);
     const minutes = Math.floor((countTimer % 3600) / 60);
     const seconds = Math.floor(countTimer % 60);
 
     const isCountdown = mode === 'countdown';
 
+    //---------- UI Element in Box  ---------- //
     const renderClock = () => {
         if (isOpen) {
             return (
@@ -351,10 +355,12 @@ export default function Pomodoro({
         setHasWarnedFiveSec(false);
     };
 
-    // ---------- Audio logic ----------
+    //        ---------- Audio logic ---------- ////
     // Initialize defaults merge & bell audio
     useEffect(() => {
-        bellAudioRef.current = new Audio('/sounds/bell.mp3');
+        bellAudioRef.current = new Audio(
+            'https://pub-1ec2ebb25bae4e50bd19e6b7b25829cc.r2.dev/School%20Bell%20Sound%20Effect%20No%20Copyright%20-%20YouTube.mp3',
+        );
         bellAudioRef.current.preload = 'auto';
     }, []);
 

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -177,15 +177,13 @@ export default function Pomodoro({
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const customBlobUrlsRef = useRef<string[]>([]);
     const idbObjectUrlRef = useRef<string | null>(null);
-    const initialSeconds = useMemo(
-        () => (defaultMode === 'countdown' ? (timerDefaultCount ?? times) * 60 : 0),
-        [defaultMode, times],
-    );
 
     const refSoundPanel = useClickOutSide<HTMLDivElement>(() => setShowSoundPanel(false));
     const refSettingsPanel = useClickOutSide<HTMLDivElement>(() => setShowSettingsPanel(false));
 
-    const [countTimer, setCountTimer] = useState<number>(initialSeconds);
+    const [countTimer, setCountTimer] = useState<number>(() =>
+        defaultMode === 'countdown' ? (timerDefaultCount ?? times) * 60 : 0,
+    );
 
     const minuteEditRef = useRef<HTMLDivElement>(null);
     const hourEditRef = useRef<HTMLDivElement>(null);

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -162,7 +162,7 @@ export default function Pomodoro({
     const ambientAudioRef = useRef<HTMLAudioElement | null>(null);
     const bellAudioRef = useRef<HTMLAudioElement | null>(null);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
-
+    const customBlobUrlsRef = useRef<string[]>([]);
     const initialSeconds = useMemo(
         () => (defaultMode === 'countdown' ? (timerDefaultCount ?? times) * 60 : 0),
         [defaultMode, times],
@@ -365,7 +365,7 @@ export default function Pomodoro({
                 ambientAudioRef.current.pause();
                 ambientAudioRef.current.src = '';
                 ambientAudioRef.current.load();
-            } catch (error) {}
+            } catch {}
         }
         if (bellAudioRef.current) {
             try {
@@ -374,6 +374,13 @@ export default function Pomodoro({
                 bellAudioRef.current.load();
             } catch {}
         }
+        // Revoke any blob: object URLs we created (legacy approach)
+        customBlobUrlsRef.current.forEach((url) => {
+            try {
+                URL.revokeObjectURL(url);
+            } catch {}
+        });
+        customBlobUrlsRef.current = [];
     };
     //        ---------- Audio logic ---------- //
 
@@ -453,7 +460,18 @@ export default function Pomodoro({
     }, [countTimer, isActive, isPause, mode, isBreakTime, hasWarnedFiveSec]);
 
     // Upload custom sound
-    const handleUploadSound = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const MAX_CUSTOM_SOUND_SIZE_MB = 15;
+
+    const fileToDataUrl = (file: File): Promise<string> => {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.onerror = reject;
+            reader.readAsDataURL(file);
+        });
+    };
+
+    const handleUploadSound = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = e.target.files;
         if (!files || !files.length) return;
         const file = files[0];
@@ -462,22 +480,54 @@ export default function Pomodoro({
         if (ambientSounds.some((s) => s.id.startsWith(file.name) && !s.builtin)) {
             toast({ description: 'Sound already added' });
         }
-        const url = URL.createObjectURL(file);
-        const newSound: AmbientSound = { id, name: file.name.replace(/\.[^.]+$/, ''), src: url, builtin: false };
-        const updated = [...(ambientSoundsLS || []), newSound];
-        // store only custom sounds (exclude builtins)
-        setAmbientSoundsLS(updated.filter((s) => !s.builtin));
-        setSelectedAmbientId(id);
-        setShowSoundPanel(true);
-        e.target.value = '';
+        if (file.size / (1024 * 1024) > MAX_CUSTOM_SOUND_SIZE_MB) {
+            toast({ description: `File too large. Max ${MAX_CUSTOM_SOUND_SIZE_MB}MB` });
+            return;
+        }
+
+        try {
+            // Convert to base64 for persistence instead of blob URL (works across reloads)
+            const dataUrl = await fileToDataUrl(file);
+            const newSound: AmbientSound = {
+                id,
+                name: file.name.replace(/\.[^.]+$/, ''),
+                src: dataUrl,
+                builtin: false,
+            };
+            const updated = [...(ambientSoundsLS || []), newSound];
+            setAmbientSoundsLS(updated.filter((s) => !s.builtin));
+            setSelectedAmbientId(id);
+            setShowSoundPanel(true);
+        } catch (err) {
+            // fallback to blob if FileReader fails unexpectedly
+            try {
+                const url = URL.createObjectURL(file);
+                customBlobUrlsRef.current.push(url);
+                const newSound: AmbientSound = {
+                    id,
+                    name: file.name.replace(/\.[^.]+$/, ''),
+                    src: url,
+                    builtin: false,
+                };
+                const updated = [...(ambientSoundsLS || []), newSound];
+                setAmbientSoundsLS(updated.filter((s) => !s.builtin));
+                setSelectedAmbientId(id);
+                setShowSoundPanel(true);
+            } catch {}
+        } finally {
+            e.target.value = '';
+        }
     };
 
     const handleRemoveCustomSound = (id: string) => {
         setAmbientSoundsLS((prev) => {
             const list = prev && Array.isArray(prev) ? prev : [];
             const target = list.find((s) => s.id === id);
+            // Revoke only if it was a blob (legacy); data URLs do not need revocation
             if (target && !target.builtin && target.src.startsWith('blob:')) {
-                URL.revokeObjectURL(target.src);
+                try {
+                    URL.revokeObjectURL(target.src);
+                } catch {}
             }
             const next = list.filter((s) => s.id !== id);
             if (selectedAmbientId === id) setSelectedAmbientId(null);

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -145,7 +145,7 @@ export default function Pomodoro({
     const [playDuringBreakVal, setPlayDuringBreakVal] = useLocalStorage<boolean>(LS_PLAY_BREAK_KEY, true);
     const [timerDefaultCount, setTimerDefaultCount] = useLocalStorage<number>(
         LS_DEFAULT_TIME_COUNT_DOWN,
-        DEFAULT_MINUTE_BREAK_TIME_COUNT_DOWN,
+        DEFAULT_MINUTE_COUNT_DOWN,
     );
     const [breakSpecificEnabled, setBreakSpecificEnabled] = useLocalStorage<boolean>(LS_BREAK_SPECIFIC_ENABLED, false);
     const [breakAmbientId, setBreakAmbientId] = useLocalStorage<string | null>(LS_BREAK_AMBIENT_ID, null);

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -4,7 +4,22 @@ import { InputHTMLAttributes, useEffect, useMemo, useRef, useState } from 'react
 import { useInterval } from '@/hooks/useInterval';
 import { Button } from '../ui/button';
 import useToggle from '@/hooks/useToggle';
-import { Clock, Timer, Play, Pause, RotateCcw, LucideSkipForward } from 'lucide-react';
+import {
+    Clock,
+    Timer,
+    Play,
+    Pause,
+    RotateCcw,
+    LucideSkipForward,
+    Music2,
+    Settings2,
+    Volume2,
+    VolumeX,
+    Trash2,
+    Upload,
+    CirclePause,
+    CirclePlay,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { toast } from '@/hooks/use-toast';
 import { Input } from '../ui/input';
@@ -90,6 +105,32 @@ export default function Pomodoro({
     const [isPause, setIsPause] = useState<boolean>(false);
     const [isBreakTime, setIsBreakTime] = useState<boolean>(false);
 
+    // Sound / audio related state
+    type AmbientSound = { id: string; name: string; src: string; builtin: boolean };
+    const LS_SOUNDS_KEY = 'POMODORO_AMBIENT_SOUNDS';
+    const LS_SELECTED_SOUND_KEY = 'POMODORO_SELECTED_AMBIENT';
+    const LS_VOLUME_KEY = 'POMODORO_VOLUME';
+    const LS_PLAY_BREAK_KEY = 'POMODORO_PLAY_DURING_BREAK';
+
+    const defaultAmbient: AmbientSound[] = [
+        { id: 'rain', name: 'Raining', src: '/sounds/raining.mp3', builtin: true },
+        { id: 'white-noise', name: 'White Noise', src: '/sounds/white-noise.mp3', builtin: true },
+        { id: 'lofi', name: 'Lofi', src: '/sounds/lofi.mp3', builtin: true },
+    ];
+
+    const [ambientSounds, setAmbientSounds] = useState<AmbientSound[]>(defaultAmbient);
+    const [selectedAmbientId, setSelectedAmbientId] = useState<string | null>(null);
+    const [volume, setVolume] = useState<number>(0.4);
+    const [playDuringBreak, setPlayDuringBreak] = useState<boolean>(true);
+    const [isAmbientPlaying, setIsAmbientPlaying] = useState<boolean>(false);
+    const [showSoundPanel, setShowSoundPanel] = useState<boolean>(false);
+    const [showSettingsPanel, setShowSettingsPanel] = useState<boolean>(false);
+    const [hasWarnedFiveSec, setHasWarnedFiveSec] = useState<boolean>(false);
+
+    const ambientAudioRef = useRef<HTMLAudioElement | null>(null);
+    const bellAudioRef = useRef<HTMLAudioElement | null>(null);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+
     const initialSeconds = useMemo(() => (defaultMode === 'countdown' ? times * 60 : 0), [defaultMode, times]);
     const [countTimer, setCountTimer] = useState<number>(initialSeconds);
 
@@ -168,6 +209,7 @@ export default function Pomodoro({
             setCountTimer(breakTime * 60);
             setIsActive(true);
             setIsOpen(true);
+            setHasWarnedFiveSec(false);
         }
     };
 
@@ -175,6 +217,7 @@ export default function Pomodoro({
         setCountTimer(defaultMode === 'countdown' ? times * 60 : 0);
         setIsActive(false);
         setIsPause(false);
+        setHasWarnedFiveSec(false);
     }, [defaultMode, times]);
 
     useInterval(() => {
@@ -278,7 +321,316 @@ export default function Pomodoro({
         const seconds = type === 'minute' ? time * 60 : time * 60 * 60;
 
         setCountTimer(seconds);
+        setHasWarnedFiveSec(false);
     };
+
+    // ---------- Audio logic ----------
+    // Load from localStorage on mount
+    useEffect(() => {
+        try {
+            const storedSounds = JSON.parse(localStorage.getItem(LS_SOUNDS_KEY) || '[]');
+            if (Array.isArray(storedSounds)) {
+                // merge defaults (avoid duplicates by id)
+                const merged = [...defaultAmbient];
+                storedSounds.forEach((s: AmbientSound) => {
+                    if (!merged.find((m) => m.id === s.id)) merged.push(s);
+                });
+                setAmbientSounds(merged);
+            }
+            const storedSelected = localStorage.getItem(LS_SELECTED_SOUND_KEY);
+            if (storedSelected) setSelectedAmbientId(storedSelected);
+            const storedVolume = localStorage.getItem(LS_VOLUME_KEY);
+            if (storedVolume) setVolume(Math.min(1, Math.max(0, parseFloat(storedVolume))));
+            const storedPlayBreak = localStorage.getItem(LS_PLAY_BREAK_KEY);
+            if (storedPlayBreak) setPlayDuringBreak(storedPlayBreak === 'true');
+        } catch (err) {
+            // ignore parse errors
+        }
+        // Prepare bell sound
+        bellAudioRef.current = new Audio('/sounds/bell.mp3');
+        bellAudioRef.current.preload = 'auto';
+    }, []);
+
+    // Persist selections
+    useEffect(() => {
+        localStorage.setItem(LS_SELECTED_SOUND_KEY, selectedAmbientId || '');
+    }, [selectedAmbientId]);
+    useEffect(() => {
+        localStorage.setItem(LS_VOLUME_KEY, String(volume));
+        if (ambientAudioRef.current) ambientAudioRef.current.volume = volume;
+        if (bellAudioRef.current) bellAudioRef.current.volume = Math.min(1, volume + 0.15); // bell a little louder
+    }, [volume]);
+    useEffect(() => {
+        localStorage.setItem(LS_PLAY_BREAK_KEY, String(playDuringBreak));
+    }, [playDuringBreak]);
+
+    // Initialize / switch ambient audio
+    useEffect(() => {
+        if (!selectedAmbientId) {
+            if (ambientAudioRef.current) {
+                ambientAudioRef.current.pause();
+            }
+            return;
+        }
+        const selected = ambientSounds.find((s) => s.id === selectedAmbientId);
+        if (!selected) return;
+        if (!ambientAudioRef.current) {
+            ambientAudioRef.current = new Audio(selected.src);
+        } else {
+            ambientAudioRef.current.src = selected.src;
+        }
+        ambientAudioRef.current.loop = true;
+        ambientAudioRef.current.volume = volume;
+        if (isActive && !isPause && (!isBreakTime || playDuringBreak)) {
+            ambientAudioRef.current
+                .play()
+                .then(() => setIsAmbientPlaying(true))
+                .catch(() => setIsAmbientPlaying(false));
+        }
+    }, [selectedAmbientId]);
+
+    // Play / pause ambient when state changes
+    useEffect(() => {
+        const audio = ambientAudioRef.current;
+        if (!audio) return;
+        if (isActive && !isPause && selectedAmbientId && (!isBreakTime || playDuringBreak)) {
+            audio
+                .play()
+                .then(() => setIsAmbientPlaying(true))
+                .catch(() => setIsAmbientPlaying(false));
+        } else {
+            audio.pause();
+            setIsAmbientPlaying(false);
+        }
+    }, [isActive, isPause, isBreakTime, playDuringBreak]);
+
+    // Five-second warning bell
+    useEffect(() => {
+        if (!isActive || isPause) return;
+        if (!isBreakTime && mode === 'countdown') {
+            if (countTimer === 5 && !hasWarnedFiveSec) {
+                if (bellAudioRef.current) {
+                    bellAudioRef.current.currentTime = 0;
+                    bellAudioRef.current.play().catch(() => {});
+                }
+                setHasWarnedFiveSec(true);
+            } else if (countTimer > 5 && hasWarnedFiveSec) {
+                // reset flag if user extends / edits time
+                setHasWarnedFiveSec(false);
+            }
+        }
+    }, [countTimer, isActive, isPause, mode, isBreakTime, hasWarnedFiveSec]);
+
+    // Upload custom sound
+    const handleUploadSound = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = e.target.files;
+        if (!files || !files.length) return;
+        const file = files[0];
+        const id = `${file.name}-${file.size}-${Date.now()}`;
+        // Prevent duplicates by name+size
+        if (ambientSounds.some((s) => s.id.startsWith(file.name) && !s.builtin)) {
+            toast({ description: 'Sound already added' });
+        }
+        const url = URL.createObjectURL(file);
+        const newSound: AmbientSound = { id, name: file.name.replace(/\.[^.]+$/, ''), src: url, builtin: false };
+        const updated = [...ambientSounds, newSound];
+        setAmbientSounds(updated);
+        try {
+            const custom = updated.filter((s) => !s.builtin);
+            localStorage.setItem(LS_SOUNDS_KEY, JSON.stringify(custom));
+        } catch {}
+        setSelectedAmbientId(id);
+        setShowSoundPanel(true);
+        e.target.value = '';
+    };
+
+    const handleRemoveCustomSound = (id: string) => {
+        setAmbientSounds((prev) => {
+            const target = prev.find((s) => s.id === id);
+            if (target && !target.builtin && target.src.startsWith('blob:')) {
+                URL.revokeObjectURL(target.src);
+            }
+            const next = prev.filter((s) => s.id !== id);
+            try {
+                const custom = next.filter((s) => !s.builtin);
+                localStorage.setItem(LS_SOUNDS_KEY, JSON.stringify(custom));
+            } catch {}
+            if (selectedAmbientId === id) setSelectedAmbientId(null);
+            return next;
+        });
+    };
+
+    const toggleAmbientPlay = () => {
+        if (!selectedAmbientId) return;
+        const audio = ambientAudioRef.current;
+        if (!audio) return;
+        if (isAmbientPlaying) {
+            audio.pause();
+            setIsAmbientPlaying(false);
+        } else {
+            audio
+                .play()
+                .then(() => setIsAmbientPlaying(true))
+                .catch(() => setIsAmbientPlaying(false));
+        }
+    };
+
+    const handleSelectAmbient = (id: string) => {
+        if (id === selectedAmbientId) {
+            toggleAmbientPlay();
+            return;
+        }
+        setSelectedAmbientId(id);
+    };
+
+    const renderSoundPanel = () => {
+        if (!showSoundPanel) return null;
+        return (
+            <motion.div
+                initial={{ opacity: 0, y: 6, scale: 0.98 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: 6, scale: 0.98 }}
+                transition={{ duration: 0.18 }}
+                className="absolute top-12 left-0 w-60 z-[100]"
+            >
+                <Card className="p-2 rounded-lg border dark:border-white/10 dark:bg-slate-900/95 backdrop-blur">
+                    <div className="flex items-center justify-between mb-1 px-1">
+                        <span className="text-xs font-semibold text-slate-300">Ambient Sounds</span>
+                        <button
+                            onClick={() => fileInputRef.current?.click()}
+                            className="p-1 rounded-md text-slate-400 hover:text-slate-100 hover:bg-slate-700/40"
+                            aria-label="Upload sound"
+                        >
+                            <Upload className="h-3.5 w-3.5" />
+                        </button>
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="audio/*"
+                            className="hidden"
+                            onChange={handleUploadSound}
+                        />
+                    </div>
+                    <div className="max-h-48 overflow-y-auto pr-1 space-y-1">
+                        {ambientSounds.map((s) => {
+                            const isSel = s.id === selectedAmbientId;
+                            return (
+                                <div
+                                    key={s.id}
+                                    className={cn(
+                                        'group flex items-center justify-between gap-2 rounded-md px-2 py-1 text-xs cursor-pointer transition',
+                                        isSel
+                                            ? 'bg-amber-500/20 text-amber-200'
+                                            : 'dark:text-slate-300 hover:bg-slate-700/40',
+                                    )}
+                                    onClick={() => handleSelectAmbient(s.id)}
+                                >
+                                    <div className="flex items-center gap-2 truncate">
+                                        {isSel ? (
+                                            isAmbientPlaying ? (
+                                                <CirclePause className="h-3.5 w-3.5" />
+                                            ) : (
+                                                <CirclePlay className="h-3.5 w-3.5" />
+                                            )
+                                        ) : (
+                                            <Music2 className="h-3.5 w-3.5 opacity-60" />
+                                        )}
+                                        <span className="truncate max-w-[120px]">{s.name}</span>
+                                    </div>
+                                    {!s.builtin && (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleRemoveCustomSound(s.id);
+                                            }}
+                                            className="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-red-500/20 text-red-300"
+                                            aria-label="Remove sound"
+                                        >
+                                            <Trash2 className="h-3 w-3" />
+                                        </button>
+                                    )}
+                                </div>
+                            );
+                        })}
+                        {ambientSounds.length === 0 && (
+                            <div className="text-[10px] text-slate-400 px-2 py-2">No sounds added.</div>
+                        )}
+                    </div>
+                </Card>
+            </motion.div>
+        );
+    };
+
+    const renderSettingsPanel = () => {
+        if (!showSettingsPanel) return null;
+        return (
+            <motion.div
+                initial={{ opacity: 0, y: 6, scale: 0.98 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: 6, scale: 0.98 }}
+                transition={{ duration: 0.18 }}
+                className="absolute top-12 right-0 w-60 z-[100]"
+            >
+                <Card className="p-3 rounded-lg border dark:border-white/10 dark:bg-slate-900/95 backdrop-blur space-y-3">
+                    <div className="flex items-center justify-between text-xs">
+                        <span className="text-slate-300 font-semibold">Settings</span>
+                        <span className="text-[10px] text-slate-500">v1</span>
+                    </div>
+                    <div className="space-y-1">
+                        <div className="flex items-center justify-between text-[11px] text-slate-300">
+                            <span>Volume</span>
+                            <span>{Math.round(volume * 100)}%</span>
+                        </div>
+                        <input
+                            type="range"
+                            min={0}
+                            max={1}
+                            step={0.01}
+                            value={volume}
+                            onChange={(e) => setVolume(parseFloat(e.target.value))}
+                            className="w-full accent-amber-400 cursor-pointer"
+                            aria-label="Ambient volume"
+                        />
+                    </div>
+                    <label className="flex items-center gap-2 text-[11px] text-slate-300 cursor-pointer select-none">
+                        <input
+                            type="checkbox"
+                            checked={playDuringBreak}
+                            onChange={(e) => setPlayDuringBreak(e.target.checked)}
+                            className="accent-amber-400"
+                        />
+                        <span>Play during break</span>
+                    </label>
+                    <button
+                        onClick={() => {
+                            setSelectedAmbientId(null);
+                            setVolume(0.4);
+                            setPlayDuringBreak(true);
+                            setIsAmbientPlaying(false);
+                        }}
+                        className="w-full text-[11px] mt-1 rounded-md bg-slate-800/60 hover:bg-slate-700/60 py-1 text-slate-300 hover:text-white"
+                    >
+                        Reset Defaults
+                    </button>
+                </Card>
+            </motion.div>
+        );
+    };
+
+    // Close panels when clicking outside
+    const panelContainerRef = useRef<HTMLDivElement | null>(null);
+    useEffect(() => {
+        if (!showSoundPanel && !showSettingsPanel) return;
+        const handler = (e: MouseEvent) => {
+            if (!panelContainerRef.current) return;
+            if (!panelContainerRef.current.contains(e.target as Node)) {
+                setShowSoundPanel(false);
+                setShowSettingsPanel(false);
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [showSoundPanel, showSettingsPanel]);
 
     // Close edit mode when clicking outside
     useEffect(() => {
@@ -431,7 +783,7 @@ export default function Pomodoro({
                             className="absolute z-50 mt-2 w-64 left-[-6em]"
                         >
                             <Card className="rounded-xl border dark:border-white/10 dark:bg-slate-900/90 dark:text-slate-100 backdrop-blur p-3 shadow-xl">
-                                <div className="flex items-center justify-between">
+                                <div className="flex items-center justify-between relative" ref={panelContainerRef}>
                                     {!isBreakTime && (
                                         <div className="inline-flex items-center rounded-lg dark:bg-slate-800/60 p-0.5">
                                             <button
@@ -458,21 +810,64 @@ export default function Pomodoro({
                                             </button>
                                         </div>
                                     )}
-                                    {!isBreakTime && (
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            onClick={handleProcessRunTimer}
-                                            className="h-8 w-8 rounded-full border border-white/10 bg-slate-800/70 hover:bg-slate-700/70"
-                                            aria-label={isActive && !isPause ? 'Pause' : 'Start'}
-                                        >
-                                            {isActive && !isPause ? (
-                                                <Pause className="h-4 w-4 text-slate-100" />
-                                            ) : (
-                                                <Play className="h-4 w-4 text-slate-100" />
+                                    <div className="flex items-center gap-1">
+                                        {!isBreakTime && (
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={handleProcessRunTimer}
+                                                className="h-8 w-8 rounded-full border border-white/10 bg-slate-800/70 hover:bg-slate-700/70"
+                                                aria-label={isActive && !isPause ? 'Pause' : 'Start'}
+                                            >
+                                                {isActive && !isPause ? (
+                                                    <Pause className="h-4 w-4 text-slate-100" />
+                                                ) : (
+                                                    <Play className="h-4 w-4 text-slate-100" />
+                                                )}
+                                            </Button>
+                                        )}
+                                        <button
+                                            onClick={() => {
+                                                setShowSoundPanel((v) => !v);
+                                                setShowSettingsPanel(false);
+                                            }}
+                                            aria-label="Ambient sounds"
+                                            className={cn(
+                                                'h-8 w-8 flex items-center justify-center rounded-full border border-white/10 bg-slate-800/70 hover:bg-slate-700/70 transition',
+                                                showSoundPanel && 'ring-1 ring-amber-300/40',
                                             )}
-                                        </Button>
-                                    )}
+                                        >
+                                            <Music2 className="h-4 w-4 text-slate-100" />
+                                        </button>
+                                        <button
+                                            onClick={() => {
+                                                setShowSettingsPanel((v) => !v);
+                                                setShowSoundPanel(false);
+                                            }}
+                                            aria-label="Settings"
+                                            className={cn(
+                                                'h-8 w-8 flex items-center justify-center rounded-full border border-white/10 bg-slate-800/70 hover:bg-slate-700/70 transition',
+                                                showSettingsPanel && 'ring-1 ring-amber-300/40',
+                                            )}
+                                        >
+                                            <Settings2 className="h-4 w-4 text-slate-100" />
+                                        </button>
+                                        {selectedAmbientId && (
+                                            <button
+                                                onClick={toggleAmbientPlay}
+                                                aria-label={isAmbientPlaying ? 'Pause ambient' : 'Play ambient'}
+                                                className="h-8 w-8 flex items-center justify-center rounded-full border border-white/10 bg-slate-800/70 hover:bg-slate-700/70 transition"
+                                            >
+                                                {isAmbientPlaying ? (
+                                                    <CirclePause className="h-4 w-4 text-slate-100" />
+                                                ) : (
+                                                    <CirclePlay className="h-4 w-4 text-slate-100" />
+                                                )}
+                                            </button>
+                                        )}
+                                    </div>
+                                    <AnimatePresence>{renderSoundPanel()}</AnimatePresence>
+                                    <AnimatePresence>{renderSettingsPanel()}</AnimatePresence>
                                 </div>
 
                                 {renderTimer()}

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -181,6 +181,9 @@ export default function Pomodoro({
         [defaultMode, times],
     );
 
+    const refSoundPanel = useClickOutSide<HTMLDivElement>(() => setShowSoundPanel(false));
+    const refSettingsPanel = useClickOutSide<HTMLDivElement>(() => setShowSettingsPanel(false));
+
     const [countTimer, setCountTimer] = useState<number>(initialSeconds);
 
     const minuteEditRef = useRef<HTMLDivElement>(null);
@@ -630,6 +633,7 @@ export default function Pomodoro({
         if (!showSoundPanel) return null;
         return (
             <motion.div
+                ref={refSoundPanel}
                 initial={{ opacity: 0, y: 6, scale: 0.98 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
                 exit={{ opacity: 0, y: 6, scale: 0.98 }}
@@ -711,6 +715,7 @@ export default function Pomodoro({
         if (!showSettingsPanel) return null;
         return (
             <motion.div
+                ref={refSettingsPanel}
                 initial={{ opacity: 0, y: 6, scale: 0.98 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
                 exit={{ opacity: 0, y: 6, scale: 0.98 }}

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -131,7 +131,16 @@ export default function Pomodoro({
         setCountTimer(() => (mode === 'countdown' ? 0 : times * 60));
     };
 
+    const validateTimer = () => {
+        if (countTimer <= 0) {
+            toast({ description: 'Please set your time session' });
+            return false;
+        }
+        return true;
+    };
     const handleProcessRunTimer = () => {
+        if (!validateTimer()) return;
+
         if (!isActive) {
             setIsActive(true);
             setIsPause(false);
@@ -256,8 +265,6 @@ export default function Pomodoro({
     };
 
     const handleOnChangeTimer = (type: TypeEditTimer, value: string) => {
-        console.log(value);
-
         if (!isNumber(value)) {
             return toast({ description: tCommon('messages.fillNumberError') });
         }

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -202,6 +202,8 @@ export default function Pomodoro({
     const handleClickEditTimer = (type: TypeEditTimer) => {
         setIsActive(false);
 
+        if (mode === 'stopwatch') return;
+
         setEditTimer({
             minute: type === 'minute',
             hour: type === 'hour',
@@ -234,6 +236,7 @@ export default function Pomodoro({
         }
         return true;
     };
+
     const handleProcessRunTimer = () => {
         if (!validateTimer()) return;
 

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -942,13 +942,81 @@ export default function Pomodoro({
         );
     };
 
+    // --------------------------- Draggable logic --------------------------- //
+    const [dragPos, setDragPos] = useState<{ x: number; y: number }>({ x: positionX, y: positionY });
+    const dragRef = useRef<HTMLDivElement | null>(null);
+    const dragDataRef = useRef<{
+        startPointerX: number;
+        startPointerY: number;
+        startX: number;
+        startY: number;
+        dragging: boolean;
+    }>({ startPointerX: 0, startPointerY: 0, startX: 0, startY: 0, dragging: false });
+
+    const handlePointerDown = (e: React.PointerEvent) => {
+        // Left button only & ignore if starting on interactive elements
+        if (e.button !== 0) return;
+        const target = e.target as HTMLElement;
+        if (
+            target.closest(
+                'button, input, textarea, select, [role="button"], [contenteditable="true"], a, svg, path, audio',
+            )
+        ) {
+            return; // do not start drag when interacting with controls
+        }
+        dragDataRef.current.startPointerX = e.clientX;
+        dragDataRef.current.startPointerY = e.clientY;
+        dragDataRef.current.startX = dragPos.x;
+        dragDataRef.current.startY = dragPos.y;
+        dragDataRef.current.dragging = true;
+
+        // Add listeners on window to track outside bounds
+        window.addEventListener('pointermove', handlePointerMove);
+        window.addEventListener('pointerup', handlePointerUp, { once: true });
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+        if (!dragDataRef.current.dragging) return;
+        const dx = e.clientX - dragDataRef.current.startPointerX;
+        const dy = e.clientY - dragDataRef.current.startPointerY;
+        setDragPos({ x: dragDataRef.current.startX + dx, y: dragDataRef.current.startY + dy });
+    };
+
+    const handlePointerUp = () => {
+        dragDataRef.current.dragging = false;
+        window.removeEventListener('pointermove', handlePointerMove);
+    };
+
+    useEffect(() => {
+        return () => {
+            window.removeEventListener('pointermove', handlePointerMove);
+            window.removeEventListener('pointerup', handlePointerUp);
+        };
+    }, []);
+
+    const isDragging = dragDataRef.current.dragging;
+
     return (
         <motion.div
-            className={cn(`max-w-[140px] transform absolute z-[99999] ${positionClass(position)}`, className)}
+            className={cn(
+                `max-w-[140px] transform absolute z-[99999] ${positionClass(position)} select-none`,
+                isDragging && 'cursor-grabbing',
+                !isDragging && 'cursor-grab',
+                className,
+            )}
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
+            ref={dragRef}
+            onPointerDown={handlePointerDown}
+            style={{ touchAction: 'none' }}
         >
-            <div style={{ transform: `translate(${positionX}px, ${positionY}px)`, willChange: 'transform' }}>
+            <div
+                style={{
+                    transform: `translate(${dragPos.x}px, ${dragPos.y}px)`,
+                    willChange: 'transform',
+                    userSelect: isDragging ? 'none' : undefined,
+                }}
+            >
                 {renderClock()}
                 <AnimatePresence>
                     {isOpen && (

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -159,7 +159,7 @@ export default function Pomodoro({
     const fileInputRef = useRef<HTMLInputElement | null>(null);
 
     const initialSeconds = useMemo(() => (defaultMode === 'countdown' ? times * 60 : 0), [defaultMode, times]);
-    const [countTimer, setCountTimer] = useState<number>(10);
+    const [countTimer, setCountTimer] = useState<number>(initialSeconds);
 
     const minuteEditRef = useRef<HTMLDivElement>(null);
     const hourEditRef = useRef<HTMLDivElement>(null);

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -110,6 +110,7 @@ export default function Pomodoro({
     const LS_SELECTED_SOUND_KEY = 'POMODORO_SELECTED_AMBIENT';
     const LS_VOLUME_KEY = 'POMODORO_VOLUME';
     const LS_PLAY_BREAK_KEY = 'POMODORO_PLAY_DURING_BREAK';
+    const LS_DEFAULT_TIME_COUNT_DOWN = 'POMODORO_DEFAULT_TIME_COUNT_DOWN';
 
     //DEFAULT SOUNDs
     const defaultAmbient: AmbientSound[] = [
@@ -137,6 +138,10 @@ export default function Pomodoro({
     const [selectedAmbientId, setSelectedAmbientId] = useLocalStorage<string | null>(LS_SELECTED_SOUND_KEY, null);
     const [volumeLS, setVolumeLS] = useLocalStorage<number>(LS_VOLUME_KEY, 0.4);
     const [playDuringBreakVal, setPlayDuringBreakVal] = useLocalStorage<boolean>(LS_PLAY_BREAK_KEY, true);
+    const [timerDefaultCount, setTimerDefaultCount] = useLocalStorage<number>(
+        LS_DEFAULT_TIME_COUNT_DOWN,
+        DEFAULT_MINUTE_BREAK_TIME_COUNT_DOWN,
+    );
 
     const ambientSounds: AmbientSound[] = useMemo(() => {
         const custom = ambientSoundsLS && Array.isArray(ambientSoundsLS) ? ambientSoundsLS : [];
@@ -158,7 +163,11 @@ export default function Pomodoro({
     const bellAudioRef = useRef<HTMLAudioElement | null>(null);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-    const initialSeconds = useMemo(() => (defaultMode === 'countdown' ? times * 60 : 0), [defaultMode, times]);
+    const initialSeconds = useMemo(
+        () => (defaultMode === 'countdown' ? (timerDefaultCount ?? times) * 60 : 0),
+        [defaultMode, times],
+    );
+
     const [countTimer, setCountTimer] = useState<number>(initialSeconds);
 
     const minuteEditRef = useRef<HTMLDivElement>(null);
@@ -186,7 +195,8 @@ export default function Pomodoro({
     const reset = () => {
         setIsActive(false);
         setIsPause(false);
-        setCountTimer(mode === 'countdown' ? times * 60 : 0);
+        const defaultUserSettingCountDown = (timerDefaultCount ?? times) * 60; //second
+        setCountTimer(mode === 'countdown' ? defaultUserSettingCountDown : 0);
     };
 
     const handleSkipBreakTime = () => {
@@ -198,7 +208,7 @@ export default function Pomodoro({
         toggleMode(mode === 'countdown' ? 'stopwatch' : 'countdown');
         setIsActive(false);
         setIsPause(false);
-        setCountTimer(() => (mode === 'countdown' ? 0 : times * 60));
+        setCountTimer(() => (mode === 'countdown' ? 0 : countTimer));
     };
 
     const validateTimer = () => {
@@ -241,13 +251,6 @@ export default function Pomodoro({
             setHasWarnedFiveSec(false);
         }
     };
-
-    useEffect(() => {
-        setCountTimer(defaultMode === 'countdown' ? times * 60 : 0);
-        setIsActive(false);
-        setIsPause(false);
-        setHasWarnedFiveSec(false);
-    }, [defaultMode, times]);
 
     useInterval(() => {
         if (!isActive || isPause) return;
@@ -347,11 +350,12 @@ export default function Pomodoro({
             return toast({ description: tCommon('messages.fillNumberPositiveError') });
         }
 
-        const time = parseFloat(value);
+        const minute = parseFloat(value);
 
-        const seconds = type === 'minute' ? time * 60 : time * 60 * 60;
+        const seconds = type === 'minute' ? minute * 60 : minute * 60 * 60;
 
         setCountTimer(seconds);
+        setTimerDefaultCount(minute);
         setHasWarnedFiveSec(false);
     };
 

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -25,6 +25,7 @@ import {
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { toast } from '@/hooks/use-toast';
+import useClickOutSide from '@/hooks/useClickOutSide';
 
 export type TypePosition = 'top-center' | 'bottom-center' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 export type TypeMode = 'countdown' | 'stopwatch';
@@ -164,6 +165,12 @@ export default function Pomodoro({
     const [showSettingsPanel, setShowSettingsPanel] = useState<boolean>(false);
     const [hasWarnedFiveSec, setHasWarnedFiveSec] = useState<boolean>(false);
 
+    //---------- Click outside container ---------- //
+    const handleClickOutSideCBoxContainer = () => {
+        setIsOpen(false);
+    };
+
+    const containerRef = useClickOutSide<HTMLDivElement>(handleClickOutSideCBoxContainer);
     const ambientAudioRef = useRef<HTMLAudioElement | null>(null);
     const bellAudioRef = useRef<HTMLAudioElement | null>(null);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -931,6 +938,7 @@ export default function Pomodoro({
                 <AnimatePresence>
                     {isOpen && (
                         <motion.div
+                            ref={containerRef}
                             initial={{ opacity: 0, scale: 0.98, y: 6 }}
                             animate={{ opacity: 1, scale: 1, y: 0 }}
                             exit={{ opacity: 0, scale: 0.98, y: 6 }}

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -304,33 +304,50 @@ export default function Pomodoro({
         const renderEditMode = () => {
             if (editTimer[type])
                 return (
-                    <Input
+                    <input
                         autoFocus
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        aria-label={type === 'hour' ? 'Edit hours' : 'Edit minutes'}
+                        className="w-full bg-transparent text-center focus:outline-none focus:ring-0 border-none p-0 m-0 text-2xl font-semibold tracking-tight caret-amber-300"
                         value={times}
                         onChange={(e) => handleOnChangeTimer(type, e.target.value)}
                         onBlur={() => setEditTimer((prev) => ({ ...prev, [type]: false }))}
                         onKeyDown={(e) => {
                             if (e.key === 'Enter') {
                                 e.preventDefault();
-                                (e.target as HTMLInputElement).blur(); // triggers onBlur to close edit mode
+                                (e.target as HTMLInputElement).blur();
                             } else if (e.key === 'Escape') {
                                 e.preventDefault();
                                 setEditTimer((prev) => ({ ...prev, [type]: false }));
+                            } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                                // Increment / decrement convenience
+                                e.preventDefault();
+                                const numeric = parseInt(times, 10) || 0;
+                                const delta = e.key === 'ArrowUp' ? 1 : -1;
+                                const next = Math.max(0, numeric + delta);
+                                handleOnChangeTimer(type, String(next).padStart(2, '0'));
                             }
                         }}
                     />
                 );
-            return times;
+            return <span className="inline-block w-full select-none">{times}</span>;
         };
 
         return (
             <div
                 ref={type == 'minute' ? minuteEditRef : hourEditRef}
-                onClick={() => handleClickEditTimer(type)}
-                className="rounded-md border dark:border-white/10 dark:bg-slate-800/60 py-2"
+                onClick={() => !editTimer[type] && handleClickEditTimer(type)}
+                className={cn(
+                    'rounded-md border dark:border-white/10 dark:bg-slate-800/60 py-2 flex flex-col items-center justify-center transition-all select-none',
+                    editTimer[type] ? 'cursor-pointer ring-1 ring-amber-300/40 shadow-inner' : 'cursor-default',
+                )}
+                style={{ minHeight: '70px' }}
             >
-                <div className="text-2xl font-semibold tracking-tight">{renderEditMode()}</div>
-                <div className="text-[10px] uppercase text-slate-400">{prefix}</div>
+                <div className="text-2xl font-semibold tracking-tight leading-none h-8 flex items-center justify-center w-full">
+                    {renderEditMode()}
+                </div>
+                <div className="text-[10px] uppercase text-slate-400 mt-1">{prefix}</div>
             </div>
         );
     };

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -8,9 +8,9 @@ import { Clock, Timer, Play, Pause, RotateCcw, LucideSkipForward } from 'lucide-
 import { cn } from '@/lib/utils';
 import { toast } from '@/hooks/use-toast';
 
-type TypePosition = 'top-center' | 'bottom-center' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-type TypeMode = 'countdown' | 'stopwatch';
-interface IPropPomodoro {
+export type TypePosition = 'top-center' | 'bottom-center' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+export type TypeMode = 'countdown' | 'stopwatch';
+export interface IPropPomodoro {
     position: TypePosition;
     positionX?: number;
     positionY?: number;

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -359,13 +359,34 @@ export default function Pomodoro({
         setHasWarnedFiveSec(false);
     };
 
-    //        ---------- Audio logic ---------- ////
+    const handleCleanUpAudio = () => {
+        if (ambientAudioRef.current) {
+            try {
+                ambientAudioRef.current.pause();
+                ambientAudioRef.current.src = '';
+                ambientAudioRef.current.load();
+            } catch (error) {}
+        }
+        if (bellAudioRef.current) {
+            try {
+                bellAudioRef.current.pause();
+                bellAudioRef.current.src = '';
+                bellAudioRef.current.load();
+            } catch {}
+        }
+    };
+    //        ---------- Audio logic ---------- //
+
     // Initialize defaults merge & bell audio
     useEffect(() => {
         bellAudioRef.current = new Audio(
             'https://pub-1ec2ebb25bae4e50bd19e6b7b25829cc.r2.dev/School%20Bell%20Sound%20Effect%20No%20Copyright%20-%20YouTube.mp3',
         );
         bellAudioRef.current.preload = 'auto';
+
+        return () => {
+            handleCleanUpAudio();
+        };
     }, []);
 
     // keep volumes in sync

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -1,30 +1,29 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useTranslations } from 'next-intl';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
-import { Card } from '../ui/card';
-import { InputHTMLAttributes, useEffect, useMemo, useRef, useState } from 'react';
 import { useInterval } from '@/hooks/useInterval';
-import { Button } from '../ui/button';
+import { cn } from '@/lib/utils';
 import useToggle from '@/hooks/useToggle';
+import { isNegative, isNumber } from '@/utils/validators';
 import {
-    Clock,
-    Timer,
-    Play,
-    Pause,
-    RotateCcw,
-    LucideSkipForward,
-    Music2,
-    Settings2,
-    Volume2,
-    VolumeX,
-    Trash2,
-    Upload,
     CirclePause,
     CirclePlay,
+    Clock,
+    LucideSkipForward,
+    Music2,
+    Pause,
+    Play,
+    RotateCcw,
+    Settings2,
+    Timer,
+    Trash2,
+    Upload,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
+
+import { Button } from '../ui/button';
+import { Card } from '../ui/card';
 import { toast } from '@/hooks/use-toast';
-import { Input } from '../ui/input';
-import { isNegative, isNumber, isPositiveNumber } from '@/utils/validators';
-import { useTranslations } from 'next-intl';
 
 export type TypePosition = 'top-center' | 'bottom-center' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 export type TypeMode = 'countdown' | 'stopwatch';
@@ -118,10 +117,22 @@ export default function Pomodoro({
         { id: 'lofi', name: 'Lofi', src: '/sounds/lofi.mp3', builtin: true },
     ];
 
-    const [ambientSounds, setAmbientSounds] = useState<AmbientSound[]>(defaultAmbient);
-    const [selectedAmbientId, setSelectedAmbientId] = useState<string | null>(null);
-    const [volume, setVolume] = useState<number>(0.4);
-    const [playDuringBreak, setPlayDuringBreak] = useState<boolean>(true);
+    const [ambientSoundsLS, setAmbientSoundsLS] = useLocalStorage<AmbientSound[]>(LS_SOUNDS_KEY, []);
+    const [selectedAmbientId, setSelectedAmbientId] = useLocalStorage<string | null>(LS_SELECTED_SOUND_KEY, null);
+    const [volumeLS, setVolumeLS] = useLocalStorage<number>(LS_VOLUME_KEY, 0.4);
+    const [playDuringBreakVal, setPlayDuringBreakVal] = useLocalStorage<boolean>(LS_PLAY_BREAK_KEY, true);
+
+    const ambientSounds: AmbientSound[] = useMemo(() => {
+        const custom = ambientSoundsLS && Array.isArray(ambientSoundsLS) ? ambientSoundsLS : [];
+        const merged = [...defaultAmbient];
+        custom.forEach((s) => {
+            if (!merged.find((m) => m.id === s.id)) merged.push(s);
+        });
+        return merged;
+    }, [ambientSoundsLS]);
+
+    const volume: number = typeof volumeLS === 'number' && !isNaN(volumeLS) ? volumeLS : 0.4;
+    const playDuringBreak: boolean = typeof playDuringBreakVal === 'boolean' ? playDuringBreakVal : true;
     const [isAmbientPlaying, setIsAmbientPlaying] = useState<boolean>(false);
     const [showSoundPanel, setShowSoundPanel] = useState<boolean>(false);
     const [showSettingsPanel, setShowSettingsPanel] = useState<boolean>(false);
@@ -325,44 +336,17 @@ export default function Pomodoro({
     };
 
     // ---------- Audio logic ----------
-    // Load from localStorage on mount
+    // Initialize defaults merge & bell audio
     useEffect(() => {
-        try {
-            const storedSounds = JSON.parse(localStorage.getItem(LS_SOUNDS_KEY) || '[]');
-            if (Array.isArray(storedSounds)) {
-                // merge defaults (avoid duplicates by id)
-                const merged = [...defaultAmbient];
-                storedSounds.forEach((s: AmbientSound) => {
-                    if (!merged.find((m) => m.id === s.id)) merged.push(s);
-                });
-                setAmbientSounds(merged);
-            }
-            const storedSelected = localStorage.getItem(LS_SELECTED_SOUND_KEY);
-            if (storedSelected) setSelectedAmbientId(storedSelected);
-            const storedVolume = localStorage.getItem(LS_VOLUME_KEY);
-            if (storedVolume) setVolume(Math.min(1, Math.max(0, parseFloat(storedVolume))));
-            const storedPlayBreak = localStorage.getItem(LS_PLAY_BREAK_KEY);
-            if (storedPlayBreak) setPlayDuringBreak(storedPlayBreak === 'true');
-        } catch (err) {
-            // ignore parse errors
-        }
-        // Prepare bell sound
         bellAudioRef.current = new Audio('/sounds/bell.mp3');
         bellAudioRef.current.preload = 'auto';
     }, []);
 
-    // Persist selections
+    // keep volumes in sync
     useEffect(() => {
-        localStorage.setItem(LS_SELECTED_SOUND_KEY, selectedAmbientId || '');
-    }, [selectedAmbientId]);
-    useEffect(() => {
-        localStorage.setItem(LS_VOLUME_KEY, String(volume));
         if (ambientAudioRef.current) ambientAudioRef.current.volume = volume;
-        if (bellAudioRef.current) bellAudioRef.current.volume = Math.min(1, volume + 0.15); // bell a little louder
+        if (bellAudioRef.current) bellAudioRef.current.volume = Math.min(1, volume + 0.15);
     }, [volume]);
-    useEffect(() => {
-        localStorage.setItem(LS_PLAY_BREAK_KEY, String(playDuringBreak));
-    }, [playDuringBreak]);
 
     // Initialize / switch ambient audio
     useEffect(() => {
@@ -433,28 +417,22 @@ export default function Pomodoro({
         }
         const url = URL.createObjectURL(file);
         const newSound: AmbientSound = { id, name: file.name.replace(/\.[^.]+$/, ''), src: url, builtin: false };
-        const updated = [...ambientSounds, newSound];
-        setAmbientSounds(updated);
-        try {
-            const custom = updated.filter((s) => !s.builtin);
-            localStorage.setItem(LS_SOUNDS_KEY, JSON.stringify(custom));
-        } catch {}
+        const updated = [...(ambientSoundsLS || []), newSound];
+        // store only custom sounds (exclude builtins)
+        setAmbientSoundsLS(updated.filter((s) => !s.builtin));
         setSelectedAmbientId(id);
         setShowSoundPanel(true);
         e.target.value = '';
     };
 
     const handleRemoveCustomSound = (id: string) => {
-        setAmbientSounds((prev) => {
-            const target = prev.find((s) => s.id === id);
+        setAmbientSoundsLS((prev) => {
+            const list = prev && Array.isArray(prev) ? prev : [];
+            const target = list.find((s) => s.id === id);
             if (target && !target.builtin && target.src.startsWith('blob:')) {
                 URL.revokeObjectURL(target.src);
             }
-            const next = prev.filter((s) => s.id !== id);
-            try {
-                const custom = next.filter((s) => !s.builtin);
-                localStorage.setItem(LS_SOUNDS_KEY, JSON.stringify(custom));
-            } catch {}
+            const next = list.filter((s) => s.id !== id);
             if (selectedAmbientId === id) setSelectedAmbientId(null);
             return next;
         });
@@ -587,7 +565,7 @@ export default function Pomodoro({
                             max={1}
                             step={0.01}
                             value={volume}
-                            onChange={(e) => setVolume(parseFloat(e.target.value))}
+                            onChange={(e) => setVolumeLS(parseFloat(e.target.value))}
                             className="w-full accent-amber-400 cursor-pointer"
                             aria-label="Ambient volume"
                         />
@@ -596,7 +574,7 @@ export default function Pomodoro({
                         <input
                             type="checkbox"
                             checked={playDuringBreak}
-                            onChange={(e) => setPlayDuringBreak(e.target.checked)}
+                            onChange={(e) => setPlayDuringBreakVal(e.target.checked)}
                             className="accent-amber-400"
                         />
                         <span>Play during break</span>
@@ -604,8 +582,8 @@ export default function Pomodoro({
                     <button
                         onClick={() => {
                             setSelectedAmbientId(null);
-                            setVolume(0.4);
-                            setPlayDuringBreak(true);
+                            setVolumeLS(0.4);
+                            setPlayDuringBreakVal(true);
                             setIsAmbientPlaying(false);
                         }}
                         className="w-full text-[11px] mt-1 rounded-md bg-slate-800/60 hover:bg-slate-700/60 py-1 text-slate-300 hover:text-white"

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { idbPutAudio, idbGetObjectUrl, idbDeleteAudio } from '@/lib/DBIndex/indexedDbAudio';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useTranslations } from 'next-intl';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
@@ -111,6 +112,8 @@ export default function Pomodoro({
     const LS_VOLUME_KEY = 'POMODORO_VOLUME';
     const LS_PLAY_BREAK_KEY = 'POMODORO_PLAY_DURING_BREAK';
     const LS_DEFAULT_TIME_COUNT_DOWN = 'POMODORO_DEFAULT_TIME_COUNT_DOWN';
+    const LS_BREAK_SPECIFIC_ENABLED = 'POMODORO_BREAK_SPECIFIC_ENABLED';
+    const LS_BREAK_AMBIENT_ID = 'POMODORO_BREAK_AMBIENT_ID';
 
     //DEFAULT SOUNDs
     const defaultAmbient: AmbientSound[] = [
@@ -142,6 +145,8 @@ export default function Pomodoro({
         LS_DEFAULT_TIME_COUNT_DOWN,
         DEFAULT_MINUTE_BREAK_TIME_COUNT_DOWN,
     );
+    const [breakSpecificEnabled, setBreakSpecificEnabled] = useLocalStorage<boolean>(LS_BREAK_SPECIFIC_ENABLED, false);
+    const [breakAmbientId, setBreakAmbientId] = useLocalStorage<string | null>(LS_BREAK_AMBIENT_ID, null);
 
     const ambientSounds: AmbientSound[] = useMemo(() => {
         const custom = ambientSoundsLS && Array.isArray(ambientSoundsLS) ? ambientSoundsLS : [];
@@ -163,6 +168,7 @@ export default function Pomodoro({
     const bellAudioRef = useRef<HTMLAudioElement | null>(null);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const customBlobUrlsRef = useRef<string[]>([]);
+    const idbObjectUrlRef = useRef<string | null>(null);
     const initialSeconds = useMemo(
         () => (defaultMode === 'countdown' ? (timerDefaultCount ?? times) * 60 : 0),
         [defaultMode, times],
@@ -381,6 +387,12 @@ export default function Pomodoro({
             } catch {}
         });
         customBlobUrlsRef.current = [];
+        if (idbObjectUrlRef.current) {
+            try {
+                URL.revokeObjectURL(idbObjectUrlRef.current);
+            } catch {}
+            idbObjectUrlRef.current = null;
+        }
     };
     //        ---------- Audio logic ---------- //
 
@@ -402,36 +414,72 @@ export default function Pomodoro({
         if (bellAudioRef.current) bellAudioRef.current.volume = Math.min(1, volume + 0.15);
     }, [volume]);
 
-    // Initialize / switch ambient audio
+    // derive current ambient id (support break-specific)
+    const currentAmbientId = useMemo(
+        () => (isBreakTime && breakSpecificEnabled ? breakAmbientId || selectedAmbientId : selectedAmbientId),
+        [isBreakTime, breakSpecificEnabled, breakAmbientId, selectedAmbientId],
+    );
+
+    // Initialize / switch ambient audio (handles IndexedDB lazy object URL)
     useEffect(() => {
-        if (!selectedAmbientId) {
-            if (ambientAudioRef.current) {
-                ambientAudioRef.current.pause();
-            }
+        const id = currentAmbientId;
+        if (!id) {
+            if (ambientAudioRef.current) ambientAudioRef.current.pause();
             return;
         }
-        const selected = ambientSounds.find((s) => s.id === selectedAmbientId);
+        const selected = ambientSounds.find((s) => s.id === id);
         if (!selected) return;
-        if (!ambientAudioRef.current) {
-            ambientAudioRef.current = new Audio(selected.src);
-        } else {
-            ambientAudioRef.current.src = selected.src;
-        }
-        ambientAudioRef.current.loop = true;
-        ambientAudioRef.current.volume = volume;
-        if (isActive && !isPause && (!isBreakTime || playDuringBreak)) {
-            ambientAudioRef.current
-                .play()
-                .then(() => setIsAmbientPlaying(true))
-                .catch(() => setIsAmbientPlaying(false));
-        }
-    }, [selectedAmbientId]);
+        const prepare = async () => {
+            let src = selected.src;
+            if (src.startsWith('indexeddb:')) {
+                const realId = src.replace('indexeddb:', '');
+                if (idbObjectUrlRef.current) {
+                    try {
+                        URL.revokeObjectURL(idbObjectUrlRef.current);
+                    } catch {}
+                    idbObjectUrlRef.current = null;
+                }
+                try {
+                    const objUrl = await idbGetObjectUrl(realId);
+                    if (objUrl) {
+                        idbObjectUrlRef.current = objUrl;
+                        src = objUrl;
+                    } else {
+                        toast({ description: 'Audio not found in storage' });
+                        return;
+                    }
+                } catch {
+                    toast({ description: 'Failed to load audio from storage' });
+                    return;
+                }
+            }
+            if (!ambientAudioRef.current) {
+                ambientAudioRef.current = new Audio(src);
+            } else {
+                ambientAudioRef.current.src = src;
+            }
+            ambientAudioRef.current.loop = true;
+            ambientAudioRef.current.volume = volume;
+            if (isActive && !isPause && (!isBreakTime || playDuringBreak || (isBreakTime && breakSpecificEnabled))) {
+                ambientAudioRef.current
+                    .play()
+                    .then(() => setIsAmbientPlaying(true))
+                    .catch(() => setIsAmbientPlaying(false));
+            }
+        };
+        prepare();
+    }, [currentAmbientId]);
 
     // Play / pause ambient when state changes
     useEffect(() => {
         const audio = ambientAudioRef.current;
         if (!audio) return;
-        if (isActive && !isPause && selectedAmbientId && (!isBreakTime || playDuringBreak)) {
+        if (
+            isActive &&
+            !isPause &&
+            currentAmbientId &&
+            (!isBreakTime || playDuringBreak || (isBreakTime && breakSpecificEnabled))
+        ) {
             audio
                 .play()
                 .then(() => setIsAmbientPlaying(true))
@@ -440,7 +488,7 @@ export default function Pomodoro({
             audio.pause();
             setIsAmbientPlaying(false);
         }
-    }, [isActive, isPause, isBreakTime, playDuringBreak]);
+    }, [isActive, isPause, isBreakTime, playDuringBreak, breakSpecificEnabled, currentAmbientId]);
 
     // Five-second warning bell
     useEffect(() => {
@@ -460,7 +508,8 @@ export default function Pomodoro({
     }, [countTimer, isActive, isPause, mode, isBreakTime, hasWarnedFiveSec]);
 
     // Upload custom sound
-    const MAX_CUSTOM_SOUND_SIZE_MB = 15;
+    const MAX_CUSTOM_SOUND_SIZE_MB = 30; // allow larger when using IndexedDB
+    const LARGE_FILE_THRESHOLD_MB = 5; // switch to IndexedDB for files larger than this
 
     const fileToDataUrl = (file: File): Promise<string> => {
         return new Promise((resolve, reject) => {
@@ -480,43 +529,43 @@ export default function Pomodoro({
         if (ambientSounds.some((s) => s.id.startsWith(file.name) && !s.builtin)) {
             toast({ description: 'Sound already added' });
         }
-        if (file.size / (1024 * 1024) > MAX_CUSTOM_SOUND_SIZE_MB) {
+        const sizeMB = file.size / (1024 * 1024);
+        if (sizeMB > MAX_CUSTOM_SOUND_SIZE_MB) {
             toast({ description: `File too large. Max ${MAX_CUSTOM_SOUND_SIZE_MB}MB` });
+            e.target.value = '';
             return;
         }
-
-        try {
-            // Convert to base64 for persistence instead of blob URL (works across reloads)
-            const dataUrl = await fileToDataUrl(file);
-            const newSound: AmbientSound = {
-                id,
-                name: file.name.replace(/\.[^.]+$/, ''),
-                src: dataUrl,
-                builtin: false,
-            };
-            const updated = [...(ambientSoundsLS || []), newSound];
-            setAmbientSoundsLS(updated.filter((s) => !s.builtin));
-            setSelectedAmbientId(id);
-            setShowSoundPanel(true);
-        } catch (err) {
-            // fallback to blob if FileReader fails unexpectedly
+        const baseName = file.name.replace(/\.[^.]+$/, '');
+        let src: string | null = null;
+        if (sizeMB > LARGE_FILE_THRESHOLD_MB) {
             try {
-                const url = URL.createObjectURL(file);
-                customBlobUrlsRef.current.push(url);
-                const newSound: AmbientSound = {
-                    id,
-                    name: file.name.replace(/\.[^.]+$/, ''),
-                    src: url,
-                    builtin: false,
-                };
-                const updated = [...(ambientSoundsLS || []), newSound];
-                setAmbientSoundsLS(updated.filter((s) => !s.builtin));
-                setSelectedAmbientId(id);
-                setShowSoundPanel(true);
-            } catch {}
-        } finally {
-            e.target.value = '';
+                await idbPutAudio(id, baseName, file);
+                src = `indexeddb:${id}`;
+            } catch {
+                toast({ description: 'IndexedDB store failed; falling back to base64.' });
+            }
         }
+        if (!src) {
+            try {
+                src = await fileToDataUrl(file);
+            } catch {
+                try {
+                    const url = URL.createObjectURL(file);
+                    customBlobUrlsRef.current.push(url);
+                    src = url;
+                } catch {
+                    toast({ description: 'Upload failed' });
+                    e.target.value = '';
+                    return;
+                }
+            }
+        }
+        const newSound: AmbientSound = { id, name: baseName, src, builtin: false };
+        const updated = [...(ambientSoundsLS || []), newSound];
+        setAmbientSoundsLS(updated.filter((s) => !s.builtin));
+        setSelectedAmbientId(id);
+        setShowSoundPanel(true);
+        e.target.value = '';
     };
 
     const handleRemoveCustomSound = (id: string) => {
@@ -529,8 +578,12 @@ export default function Pomodoro({
                     URL.revokeObjectURL(target.src);
                 } catch {}
             }
+            if (target && target.src.startsWith('indexeddb:')) {
+                idbDeleteAudio(id).catch(() => {});
+            }
             const next = list.filter((s) => s.id !== id);
             if (selectedAmbientId === id) setSelectedAmbientId(null);
+            if (breakAmbientId === id) setBreakAmbientId(null);
             return next;
         });
     };
@@ -551,6 +604,14 @@ export default function Pomodoro({
     };
 
     const handleSelectAmbient = (id: string) => {
+        if (isBreakTime && breakSpecificEnabled) {
+            if (id === breakAmbientId) {
+                toggleAmbientPlay();
+                return;
+            }
+            setBreakAmbientId(id);
+            return;
+        }
         if (id === selectedAmbientId) {
             toggleAmbientPlay();
             return;
@@ -570,7 +631,9 @@ export default function Pomodoro({
             >
                 <Card className="p-2 rounded-lg border dark:border-white/10 dark:bg-slate-900/95 backdrop-blur">
                     <div className="flex items-center justify-between mb-1 px-1">
-                        <span className="text-xs font-semibold text-slate-300">Ambient Sounds</span>
+                        <span className="text-xs font-semibold text-slate-300">
+                            Ambient Sounds {isBreakTime && breakSpecificEnabled && '(Break)'}
+                        </span>
                         <button
                             onClick={() => fileInputRef.current?.click()}
                             className="p-1 rounded-md text-slate-400 hover:text-slate-100 hover:bg-slate-700/40"
@@ -588,7 +651,8 @@ export default function Pomodoro({
                     </div>
                     <div className="max-h-48 overflow-y-auto pr-1 space-y-1">
                         {ambientSounds.map((s) => {
-                            const isSel = s.id === selectedAmbientId;
+                            const activeId = isBreakTime && breakSpecificEnabled ? breakAmbientId : selectedAmbientId;
+                            const isSel = s.id === activeId;
                             return (
                                 <div
                                     key={s.id}
@@ -676,11 +740,27 @@ export default function Pomodoro({
                         />
                         <span>Play during break</span>
                     </label>
+                    <label className="flex items-center gap-2 text-[11px] text-slate-300 cursor-pointer select-none">
+                        <input
+                            type="checkbox"
+                            checked={breakSpecificEnabled}
+                            onChange={(e) => setBreakSpecificEnabled(e.target.checked)}
+                            className="accent-amber-400"
+                        />
+                        <span>Distinct break ambient</span>
+                    </label>
+                    {breakSpecificEnabled && (
+                        <div className="text-[11px] text-slate-400">
+                            Select different sound during break via sound panel.
+                        </div>
+                    )}
                     <button
                         onClick={() => {
                             setSelectedAmbientId(null);
+                            setBreakAmbientId(null);
                             setVolumeLS(0.4);
                             setPlayDuringBreakVal(true);
+                            setBreakSpecificEnabled(false);
                             setIsAmbientPlaying(false);
                         }}
                         className="w-full text-[11px] mt-1 rounded-md bg-slate-800/60 hover:bg-slate-700/60 py-1 text-slate-300 hover:text-white"

--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -111,10 +111,26 @@ export default function Pomodoro({
     const LS_VOLUME_KEY = 'POMODORO_VOLUME';
     const LS_PLAY_BREAK_KEY = 'POMODORO_PLAY_DURING_BREAK';
 
+    //DEFAULT SOUNDs
     const defaultAmbient: AmbientSound[] = [
-        { id: 'rain', name: 'Raining', src: '/sounds/raining.mp3', builtin: true },
-        { id: 'white-noise', name: 'White Noise', src: '/sounds/white-noise.mp3', builtin: true },
-        { id: 'lofi', name: 'Lofi', src: '/sounds/lofi.mp3', builtin: true },
+        {
+            id: 'rain',
+            name: 'Raining',
+            src: 'https://pub-1ec2ebb25bae4e50bd19e6b7b25829cc.r2.dev/45%20Minutes%20of%20Light%20Rain%20Sounds%20for%20Focus,%20Relaxing%20and%20Sleep%20%20Epidemic%20Ambience%20-%20YouTube.mp3',
+            builtin: true,
+        },
+        {
+            id: 'white-noise',
+            name: 'White Noise',
+            src: 'https://pub-1ec2ebb25bae4e50bd19e6b7b25829cc.r2.dev/White-Noise-Dozu-Pomodoro.mp3',
+            builtin: true,
+        },
+        {
+            id: 'lofi',
+            name: 'Lofi',
+            src: 'https://pub-1ec2ebb25bae4e50bd19e6b7b25829cc.r2.dev/Lofi-Timer-Dozo-Pomodoro-Deep-Focus.mp3',
+            builtin: true,
+        },
     ];
 
     const [ambientSoundsLS, setAmbientSoundsLS] = useLocalStorage<AmbientSound[]>(LS_SOUNDS_KEY, []);

--- a/src/components/toolbar/Navbar.tsx
+++ b/src/components/toolbar/Navbar.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import Link from 'next/link';
+import { useSelector } from 'react-redux';
 import { useAuth } from '@/contexts/auth/AuthContext';
 import { useRoleChecker } from '@/hooks/useRoleChecker';
 import { useRouter } from 'next/navigation';
 import { Suspense } from 'react';
 import { ShowIf } from '../ui/ShowIf';
 import { LearningModeSelect } from './LearningModeSelect';
+import { RootState } from '@/stores/store';
+import Pomodoro from '../pomodoro/Pomodoro';
 
 function TokenHandler() {
     // const dispatch = useAppDispatch();
@@ -27,6 +30,7 @@ export default function Navbar() {
     const { isAuthenticated, clearAuthData } = useAuth();
     const { isStudent } = useRoleChecker();
     const router = useRouter();
+    const { isDisplay: isDisplayPomodoro } = useSelector((state: RootState) => state.pomodoro);
 
     // useEffect(() => {
     //     const refreshToken = async () => {
@@ -72,9 +76,7 @@ export default function Navbar() {
                         <LearningModeSelect />
                     </ShowIf>
                 </div>
-                <div className="flex items-center gap-3 text-[0.65rem] uppercase tracking-wide text-muted-foreground/70">
-                    {/* <span className="hidden sm:inline">Knowledge Platform</span> */}
-                </div>
+                {isDisplayPomodoro && <Pomodoro position="top-center" positionY={-6} positionX={-30} />}
             </div>
 
             <Suspense fallback={null}>

--- a/src/components/toolbar/Navbar.tsx
+++ b/src/components/toolbar/Navbar.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import Link from 'next/link';
+import { RootState } from '@/stores/store';
 import { useSelector } from 'react-redux';
 import { useAuth } from '@/contexts/auth/AuthContext';
 import { useRoleChecker } from '@/hooks/useRoleChecker';
 import { useRouter } from 'next/navigation';
-import { Suspense } from 'react';
+import { Fragment, Suspense } from 'react';
 import { ShowIf } from '../ui/ShowIf';
 import { LearningModeSelect } from './LearningModeSelect';
-import { RootState } from '@/stores/store';
 import Pomodoro from '../pomodoro/Pomodoro';
 
 function TokenHandler() {
@@ -63,7 +63,7 @@ export default function Navbar() {
     // }, []);
 
     return (
-        <>
+        <Fragment>
             <div className="mx-auto flex px-4 py-2 justify-between items-center h-full border-b border-transparent bg-gradient-to-r from-background/70 via-background/40 to-background/70 dark:from-slate-950/60 dark:via-slate-900/40 dark:to-slate-950/60 backdrop-blur-md supports-[backdrop-filter]:bg-background/40">
                 <div className="flex items-center gap-3">
                     <Link
@@ -82,6 +82,6 @@ export default function Navbar() {
             <Suspense fallback={null}>
                 <TokenHandler />
             </Suspense>
-        </>
+        </Fragment>
     );
 }

--- a/src/hooks/useActivePomodoro.tsx
+++ b/src/hooks/useActivePomodoro.tsx
@@ -1,0 +1,21 @@
+/**
+ *
+ */
+
+import { IPropPomodoro } from '@/components/pomodoro/Pomodoro';
+import { setDisplayPomodoro } from '@/stores/features/pomodoro/pomodoroSlice';
+import { useAppDispatch } from '@/stores/hooks';
+import { useEffect } from 'react';
+
+type IArgPomodoro = Partial<Pick<IPropPomodoro, 'positionX' | 'positionY' | 'position'>>;
+
+export default function useActivePomodoro(options?: IArgPomodoro) {
+    const dispatch = useAppDispatch();
+
+    useEffect(() => {
+        dispatch(setDisplayPomodoro(true));
+        () => {
+            dispatch(setDisplayPomodoro(false));
+        };
+    }, []);
+}

--- a/src/hooks/useActivePomodoro.tsx
+++ b/src/hooks/useActivePomodoro.tsx
@@ -1,11 +1,7 @@
-/**
- *
- */
-
-import { IPropPomodoro } from '@/components/pomodoro/Pomodoro';
-import { setDisplayPomodoro } from '@/stores/features/pomodoro/pomodoroSlice';
-import { useAppDispatch } from '@/stores/hooks';
 import { useEffect } from 'react';
+import { useAppDispatch } from '@/stores/hooks';
+import { setDisplayPomodoro } from '@/stores/features/pomodoro/pomodoroSlice';
+import { IPropPomodoro } from '@/components/pomodoro/Pomodoro';
 
 type IArgPomodoro = Partial<Pick<IPropPomodoro, 'positionX' | 'positionY' | 'position'>>;
 
@@ -14,8 +10,8 @@ export default function useActivePomodoro(options?: IArgPomodoro) {
 
     useEffect(() => {
         dispatch(setDisplayPomodoro(true));
-        () => {
+        return () => {
             dispatch(setDisplayPomodoro(false));
         };
-    }, []);
+    }, [dispatch]);
 }

--- a/src/hooks/useClickOutSide.ts
+++ b/src/hooks/useClickOutSide.ts
@@ -1,19 +1,19 @@
 import { useEffect, useRef } from 'react';
 
-function useClickOutSide(handler: () => void) {
-  const ref = useRef<HTMLElement | null>(null);
+function useClickOutSide<T extends HTMLElement>(handler: () => void) {
+    const ref = useRef<T | null>(null);
 
-  useEffect(() => {
-    const handleClickOutSide = (e: MouseEvent) => {
-      if (ref?.current && !ref.current.contains(e.target as Node)) {
-        handler();
-      }
-    };
-    document.addEventListener('click', handleClickOutSide);
-    return () => document.removeEventListener('click', handleClickOutSide);
-  }, [handler]);
+    useEffect(() => {
+        const handleClickOutSide = (e: MouseEvent) => {
+            if (ref?.current && !ref.current.contains(e.target as Node)) {
+                handler();
+            }
+        };
+        document.addEventListener('click', handleClickOutSide);
+        return () => document.removeEventListener('click', handleClickOutSide);
+    }, [handler]);
 
-  return ref;
+    return ref;
 }
 export default useClickOutSide;
 /**

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -28,6 +28,7 @@ export async function getMessages(locale: string) {
         ...(await import(`../../messages/${locale}/schedule.json`)).default,
         ...(await import(`../../messages/${locale}/games.json`)).default,
         ...(await import(`../../messages/${locale}/class-based/class.json`)).default,
+        ...(await import(`../../messages/${locale}/pomodoro.json`)).default,
     };
 
     // You can dynamically load additional message files based on routes/features

--- a/src/lib/DBIndex/indexedDbAudio.ts
+++ b/src/lib/DBIndex/indexedDbAudio.ts
@@ -1,0 +1,94 @@
+// Utility for storing and retrieving audio files in IndexedDB
+// Provides simple put/get/delete/clear operations plus size threshold logic.
+// We namespace the DB per application and keep a single object store `audio_files`.
+// Keys are string IDs (sound ids). Values are { blob: Blob, createdAt: number, name: string }.
+
+const DB_NAME = 'pomodoro_audio_db';
+const STORE_NAME = 'audio_files';
+const DB_VERSION = 1;
+
+export interface IndexedDBAudioRecord {
+    id: string;
+    name: string;
+    blob: Blob;
+    createdAt: number;
+}
+
+function openDB(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, DB_VERSION);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+            }
+        };
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => resolve(request.result);
+    });
+}
+
+export async function idbPutAudio(id: string, name: string, blob: Blob) {
+    const db = await openDB();
+    return new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        const store = tx.objectStore(STORE_NAME);
+        const record: IndexedDBAudioRecord = { id, name, blob, createdAt: Date.now() };
+        store.put(record);
+    });
+}
+
+export async function idbGetAudio(id: string): Promise<IndexedDBAudioRecord | undefined> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        tx.onerror = () => reject(tx.error);
+        const store = tx.objectStore(STORE_NAME);
+        const req = store.get(id);
+        req.onsuccess = () => resolve(req.result as IndexedDBAudioRecord | undefined);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+export async function idbDeleteAudio(id: string) {
+    const db = await openDB();
+    return new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        const store = tx.objectStore(STORE_NAME);
+        store.delete(id);
+    });
+}
+
+export async function idbClearAll() {
+    const db = await openDB();
+    return new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readwrite');
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        const store = tx.objectStore(STORE_NAME);
+        store.clear();
+    });
+}
+
+export async function idbListIds(): Promise<string[]> {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, 'readonly');
+        tx.onerror = () => reject(tx.error);
+        const store = tx.objectStore(STORE_NAME);
+        const req = store.getAllKeys();
+        req.onsuccess = () => resolve(req.result as string[]);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+// Convenience that returns an object URL (caller should revoke when done)
+export async function idbGetObjectUrl(id: string): Promise<string | undefined> {
+    const rec = await idbGetAudio(id);
+    if (!rec) return undefined;
+    return URL.createObjectURL(rec.blob);
+}

--- a/src/lib/DBIndex/indexedDbAudio.ts
+++ b/src/lib/DBIndex/indexedDbAudio.ts
@@ -16,7 +16,15 @@ export interface IndexedDBAudioRecord {
 
 function openDB(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
-        const request = indexedDB.open(DB_NAME, DB_VERSION);
+        const idbFactory: IDBFactory | undefined =
+            typeof globalThis !== 'undefined' && 'indexedDB' in globalThis
+                ? (globalThis as any).indexedDB
+                : undefined;
+        if (!idbFactory) {
+            reject(new Error('IndexedDB is not available in this environment.'));
+            return;
+        }
+        const request = idbFactory.open(DB_NAME, DB_VERSION);
         request.onupgradeneeded = () => {
             const db = request.result;
             if (!db.objectStoreNames.contains(STORE_NAME)) {
@@ -24,7 +32,11 @@ function openDB(): Promise<IDBDatabase> {
             }
         };
         request.onerror = () => reject(request.error);
-        request.onsuccess = () => resolve(request.result);
+        request.onsuccess = () => {
+            const db = request.result;
+            db.onversionchange = () => db.close();
+            resolve(db);
+        };
     });
 }
 

--- a/src/stores/features/pomodoro/pomodoroSlice.ts
+++ b/src/stores/features/pomodoro/pomodoroSlice.ts
@@ -1,0 +1,24 @@
+import { RootState } from '@/stores/store';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type InitialState = {
+    isDisplay: boolean;
+};
+
+// state is learningMode itself
+const initialState: InitialState = {
+    isDisplay: false,
+};
+
+const pomodoroSlice = createSlice({
+    name: 'pomodoro',
+    initialState,
+    reducers: {
+        setDisplayPomodoro: (state, action: PayloadAction<boolean | null | undefined>) => {
+            state.isDisplay = !!action.payload;
+        },
+    },
+});
+
+export const { setDisplayPomodoro } = pomodoroSlice.actions;
+export default pomodoroSlice.reducer;

--- a/src/stores/features/pomodoro/pomodoroSlice.ts
+++ b/src/stores/features/pomodoro/pomodoroSlice.ts
@@ -14,7 +14,7 @@ const pomodoroSlice = createSlice({
     name: 'pomodoro',
     initialState,
     reducers: {
-        setDisplayPomodoro: (state, action: PayloadAction<boolean | null | undefined>) => {
+        setDisplayPomodoro: (state, action: PayloadAction<boolean>) => {
             state.isDisplay = !!action.payload;
         },
     },

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -4,16 +4,21 @@ import selectedNodeSlice from './features/mindmap/selectedNodeSlice';
 import subscriptionSlice from './features/subscription/subscriptionSlice';
 import learningModeSlice from './features/class-based-learning/learningModeSlice';
 import inputSetSlice from './features/inputSet/inputSetSlice';
+import pomodoroSlice from './features/pomodoro/pomodoroSlice';
 
 export const store = configureStore({
     reducer: {
         auth: authSlice,
+
         selectedNodeSlice: selectedNodeSlice,
+
         subscription: subscriptionSlice,
 
         learningMode: learningModeSlice,
 
         inputSet: inputSetSlice,
+
+        pomodoro: pomodoroSlice,
     },
     devTools: process.env.NODE_ENV !== 'production',
 });

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -6,26 +6,22 @@
  *
  */
 const validateDate = (dateStr: string): boolean => {
-  const regex = /^(\d{4})[-\/\.](\d{2})[-\/\.](\d{2})$/;
+    const regex = /^(\d{4})[-\/\.](\d{2})[-\/\.](\d{2})$/;
 
-  const match = dateStr.match(regex);
-  if (!match) {
-    return false;
-  }
+    const match = dateStr.match(regex);
+    if (!match) {
+        return false;
+    }
 
-  const [, year, month, day] = match;
-  const parsedYear = parseInt(year, 10);
-  const parsedMonth = parseInt(month, 10) - 1;
-  const parsedDay = parseInt(day, 10);
+    const [, year, month, day] = match;
+    const parsedYear = parseInt(year, 10);
+    const parsedMonth = parseInt(month, 10) - 1;
+    const parsedDay = parseInt(day, 10);
 
-  // Check if the date is valid by constructing a new Date object
-  const date = new Date(parsedYear, parsedMonth, parsedDay);
+    // Check if the date is valid by constructing a new Date object
+    const date = new Date(parsedYear, parsedMonth, parsedDay);
 
-  return (
-    date.getFullYear() === parsedYear &&
-    date.getMonth() === parsedMonth &&
-    date.getDate() === parsedDay
-  );
+    return date.getFullYear() === parsedYear && date.getMonth() === parsedMonth && date.getDate() === parsedDay;
 };
 
 /**
@@ -35,16 +31,46 @@ const validateDate = (dateStr: string): boolean => {
  * @param num - The value to be checked, which can be of type number, string, undefined, null, or bigint.
  * @returns boolean - Returns true if the input is a valid number, otherwise false.
  */
-const isNumber = (
-  num: number | string | undefined | null | bigint,
-): boolean => {
-  if (num === undefined || num === null) return false;
+const isNumber = (num: number | string | undefined | null | bigint): boolean => {
+    if (num === undefined || num === null) return false;
 
-  if (typeof num === 'string') {
+    if (typeof num === 'string') {
+        return !isNaN(Number(num));
+    }
+
     return !isNaN(Number(num));
-  }
-
-  return !isNaN(Number(num));
 };
 
-export { validateDate, isNumber };
+/**
+ * Checks if the provided value is a positive number (> 0).
+ * Supports number, bigint, and numeric strings.
+ * Returns false for: undefined, null, non-numeric strings, NaN, 0, negatives, Infinity.
+ */
+const isPositiveNumber = (num: number | string | undefined | null | bigint) => {
+    if (!isNumber(num)) return false;
+
+    if (typeof num === 'bigint') return num > BigInt(0);
+
+    const value = typeof num === 'string' ? Number(num.trim()) : num;
+    if (!isFinite(value as number)) return false;
+
+    return (num as number) > 0;
+};
+
+/**
+ * Checks if the provided value is a negative number (< 0).
+ * Supports number, bigint, and numeric strings.
+ * Returns false for: undefined, null, non-numeric strings, NaN, 0, negatives, Infinity.
+ */
+const isNegative = (num: number | string | undefined | null | bigint) => {
+    if (!isNumber(num)) return false;
+
+    if (typeof num === 'bigint') return num < BigInt(0);
+
+    const value = typeof num === 'string' ? Number(num.trim()) : num;
+    if (!isFinite(value as number)) return false;
+
+    return (num as number) < 0;
+};
+
+export { validateDate, isNumber, isPositiveNumber, isNegative };


### PR DESCRIPTION
#Fix bug related
Feats:
+ https://github.com/perinst/dozu-ui-service/issues/261

Fix overlay for sidebar by pomodoro : 
+ #260

# Pomodoro Mechanism

- Move pomodoro component for header 
- using hook for trigger display pomodoro for specific page


# Pomodoro Ambient Sounds

Place default and custom ambient sound files in this folder.

## Default Built-in Sounds (expected filenames)
- raining.mp3  (Rain ambience)
- white-noise.mp3  (Soft white noise)
- lofi.mp3  (Lofi chill loop)
- bell.mp3  (Short bell ring for 5-second warning)

These are referenced directly by the Pomodoro component:
```
/sounds/raining.mp3
/sounds/white-noise.mp3
/sounds/lofi.mp3
/sounds/bell.mp3
```

## Custom User Sounds
Users can add a custom sound via the upload button in the Pomodoro UI. Custom sounds are:
- Stored as blob Object URLs in memory for the current session
- Persisted in localStorage (metadata only) under the key `POMODORO_AMBIENT_SOUNDS`
- Re-created on next load if the file path is still valid (NOTE: For full persistence across devices you would need an upload backend)

## LocalStorage Keys
- `POMODORO_AMBIENT_SOUNDS`: JSON array of custom sound metadata `{ id, name, src, builtin: false }`
- `POMODORO_SELECTED_AMBIENT`: ID of the currently selected ambient sound
- `POMODORO_VOLUME`: Volume (0..1)
- `POMODORO_PLAY_DURING_BREAK`: Whether the ambient sound continues playing during break sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pomodoro timer added to the top bar with ambient sounds (built‑in + uploads), volume/break options, countdown bell, timer/stopwatch modes, in-place time editing, settings, and a clearer flashcards empty state with a Go Back action.
* **Localization**
  * Added English and Vietnamese translations for Pomodoro UI, flashcards empty state, and numeric input validation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->