### PR TITLE
fix(pomodoro): reset mechanism for countdown mode follow by default s…

### DIFF
--- a/src/components/pomodoro/Pomodoro.tsx
+++ b/src/components/pomodoro/Pomodoro.tsx
@@ -225,11 +225,12 @@ export default function Pomodoro({
         toggleMode(mode === 'countdown' ? 'stopwatch' : 'countdown');
         setIsActive(false);
         setIsPause(false);
-        setCountTimer(() => (mode === 'countdown' ? 0 : countTimer));
+        const defaultUserSettingCountDown = (timerDefaultCount ?? times) * 60;
+        setCountTimer(() => (mode === 'countdown' ? 0 : defaultUserSettingCountDown));
     };
 
     const validateTimer = () => {
-        if (countTimer <= 0) {
+        if (mode == 'countdown' && countTimer <= 0) {
             toast({ description: tPomodoro('timer.setTimeToast') });
             return false;
         }


### PR DESCRIPTION
…etting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Switching to countdown now auto-initializes to your configured default duration instead of zero.

- Bug Fixes
  - Switching to stopwatch now resets the timer to 0 instead of carrying over the previous value.
  - Starting a stopwatch from 0 no longer shows an error message; validation only applies in countdown mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->