### PR TITLE
feat(flashcards-quiz): quick-quiz milestones at 50%/100% with session…

### DIFF
--- a/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
+++ b/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
@@ -321,11 +321,11 @@ export default function Page() {
         await q.startFullCatchUpAll(cards);
     };
 
-    const onSkipFull = () => {
-        const { onlySecond } = q.getFullRanges();
-        const cards = studied.slice(onlySecond.start, onlySecond.end);
-        q.skipFullQuiz(cards);
-    };
+
+const onSkipFull = () => {
+  const { onlySecond } = q.getFullCards();
+  q.skipFullQuiz(onlySecond);
+};
 
     return (
         <>

--- a/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
+++ b/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
@@ -2,11 +2,9 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useFetch from '@/hooks/useFetch';
-import { putRequest } from '@/api/api';
 import LoadingPage from '@/app/loading';
 import { FlashcardLearning } from '../components/FlashcardLearning';
 import { useParams, useRouter } from 'next/navigation';
-import { toast } from '@/hooks/use-toast';
 import { useUserTrackingContext } from '@/contexts/tracking/UserTrackingContext';
 import {
     IAnkiCardReviewed,
@@ -16,24 +14,20 @@ import {
     IFlashcard,
     IQualityResponseNextReviewInterval,
 } from '../../types/flashcard.type';
-import { IItemStatus, IQualityResponse } from '@/types/itemSpacedRepetitionTracking.type';
 import flashcardService, {
     IFlashcardReviewByAnkiPayload,
-    IFlashcardReviewPayload,
 } from '@/services/flashcard/flashcard.service';
 import usePost from '@/hooks/usePost';
 import toastHelper from '@/utils/toast.helper';
 import { Button } from '@/components/ui/button';
 import { useTranslations } from 'next-intl';
-
 import { useGenerateFromExisting } from '@/app/[locale]/generate/hooks/useGenerateFromExisting';
-import { handleConvertToQuestionsEdited } from '@/app/[locale]/question/utils/handleConvertToQuestionsEdited';
-import { CONTENT_TYPE_GENERATE, IQuestionsFromSSERaw } from '@/app/[locale]/generate/types';
-import { writeLocalQuiz } from '@/app/[locale]/quiz/utils/localQuiz.storage';
-import { buildPayloadFromLearnedFlashcards } from '@/app/[locale]/question/utils/buildGenPayload';
 import { isAfter } from 'date-fns';
 import { ROUTES } from '@/utils/constants/routes';
 import { METHOD_LEARNING } from '@/utils/constants/method';
+import QuickQuizPrompt from '@/app/[locale]/flashcards/learning/components/QuickQuizPrompt';
+import { useQuizMilestones, type QuizCard } from '@/app/[locale]/flashcards/learning/hooks/useQuizMilestones';
+import BacklogCTA from '@/app/[locale]/flashcards/learning/components/BacklogCTA';
 
 export type IFlashcardWithReviewPrediction = Pick<
     IFlashcard,
@@ -53,18 +47,17 @@ export default function Page() {
     const tFlashcardLearning = useTranslations('flashcard.learning');
     const { topicId } = params as { topicId: string };
 
-    // initial total when fetched
-    const [initialTotal, setInitialTotal] = useState<number>(0);
-    // List of lessons learned (reviewed)
-    const [studied, setStudied] = useState<IDueAnkiCard[]>([]);
-    // "chunk 20%" completed
-    const [chunksDone, setChunksDone] = useState<number>(0);
-    // preparing quiz for chunk number (to navigate when SSE is done)
-    const [pendingChunk, setPendingChunk] = useState<number | null>(null);
+    // studied list to slice payload at 100% mark
+    const [studied, setStudied] = useState<QuizCard[]>([]);
 
-    const { regenerate, sseData, sseStatus, loading } = useGenerateFromExisting();
-
-    const isGenerating = pendingChunk !== null && (loading || sseStatus === 'open');
+    // helper to standardize quiz cards
+    const toQuizCard = (c: any): QuizCard => ({
+       flashcardId: c.flashcardId,
+       front: c.front,
+       back: c.back,
+       imageUrl: c.imageUrl ?? null,
+       topicName: c.topicName ?? null,
+    });
 
     // Learning tracking integration
     const {
@@ -95,9 +88,21 @@ export default function Page() {
         [IAnkiStatus.REVIEW]: 0,
     });
 
+    // gen & SSE
+    const { regenerate, sseData, sseStatus, loading } = useGenerateFromExisting();
+
+    // milestones 50% + 100%
+    const q = useQuizMilestones({
+        topicId,
+        regenerate,
+        sseData,
+        sseStatus,
+        loading,
+        chunkRatio: 0.5,
+    });
+
     useEffect(() => {
         if (flashcards && flashcards.length > 0) {
-            setInitialTotal(flashcards.length);
             if (firstToFetchFlashcards.current) {
                 const counter: IFlashcardStatusCounts = {
                     [IAnkiStatus.NEW]: 0,
@@ -112,38 +117,14 @@ export default function Page() {
                 setFlashcardsStatusCounts(counter);
                 firstToFetchFlashcards.current = false;
             }
+            q.ensureBaseline(flashcards.length);
         }
     }, [flashcards]);
 
-    const chunkSize = Math.max(1, Math.ceil(initialTotal * 0.2)); // luôn >=1
-
-    // Wait for SSE "completed" -> parse -> save local -> redirect to local quiz page
+    // reset studied when starting new session / closing session
     useEffect(() => {
-        const raw = (sseData as any)?.data?.data as IQuestionsFromSSERaw | undefined;
-        const payloadStatus = (sseData as any)?.data?.status ?? (sseData as any)?.status;
-
-        // only process while waiting for a specific chunk
-        if (pendingChunk === null) return;
-
-        const isCompleted = sseStatus === 'completed' || payloadStatus === 'completed';
-        if (!isCompleted) return;
-        if (!Array.isArray(raw) || raw.length === 0) return;
-
-        const parsed = handleConvertToQuestionsEdited({
-            type: 'generative',
-            questionsProp: raw,
-        });
-
-        const toStore = parsed.map((q) => ({
-            questionText: q.questionText,
-            choices: q.choices,
-            correctIndex: q.correctIndex,
-        }));
-
-        writeLocalQuiz(topicId, toStore);
-
-        router.push(`/quiz/local?topicId=${topicId}&chunk=${pendingChunk}`);
-    }, [sseStatus, sseData, pendingChunk, topicId, router]);
+        setStudied([]);
+    }, [q.sessionEpoch]);
 
     const currentFlashcard = flashcards ? flashcards[0] : null;
 
@@ -208,34 +189,11 @@ export default function Page() {
                 }
                 setFlashcardsData(flashcardsUpdated);
 
-                const newStudied = [...studied, currentFlashcard];
-                setStudied(newStudied);
-
                 // Update learning tracking metrics using context methods
                 updateItemsStudied(itemsStudiedCount + 1);
                 // Identify correct answers by Selecting rating >= HARD
                 if (data?.rating && data.rating >= IAnkiRating.HARD) {
                     updateCorrectAnswers(correctAnswersCount + 1);
-                }
-
-                // If finish learning the new 20% chunk -> ask gen quiz
-                const studiedCountAfter = newStudied.length;
-                const nextChunk = chunksDone + 1;
-                const nextThreshold = nextChunk * chunkSize;
-                const justReachedNewChunk = studiedCountAfter >= nextThreshold;
-
-                if (justReachedNewChunk && !loading && pendingChunk === null) {
-                    const ok = window.confirm('Bạn đã học xong 20% bài. Bạn có muốn làm quiz nhanh không?');
-                    if (ok) {
-                        const start = chunksDone * chunkSize;
-                        const end = Math.min(start + chunkSize, studiedCountAfter);
-                        const chunkCards = newStudied.slice(start, end);
-
-                        const payload = buildPayloadFromLearnedFlashcards(topicId, chunkCards);
-                        setPendingChunk(nextChunk);
-                        await regenerate(payload, 'quiz'); // SSE completed sẽ redirect
-                    }
-                    setChunksDone(nextChunk);
                 }
 
                 // If this was the last card, save progress to database using context method
@@ -318,8 +276,21 @@ export default function Page() {
                 flashcardId,
                 rating,
             });
+            
+            // Avoid double-remove if refetch is present
+            const next = flashcards[0]?.flashcardId === flashcardId
+                ? flashcards.slice(1)
+                : flashcards;
+            setFlashcardsData(next);
+
+            // update studied
+            const newStudied = [...studied, toQuizCard(currentFlashcard)];
+            setStudied(newStudied);
+
+            // Push progress to hook to decide whether to show prompt at 50%/100%
+            q.onStudiedProgress(newStudied, next.length);
         },
-        [flashcards, currentFlashcard],
+        [flashcards, currentFlashcard, studied, q],
     );
 
     function handleBackClick() {
@@ -338,22 +309,88 @@ export default function Page() {
         return <LoadingPage />;
     }
 
-    if (flashcards.length === 0 || !currentFlashcard) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
-                <div className="text-center space-y-4">
-                    <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center border border-gray-200">
-                        <svg className="w-8 h-8 text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                            />
-                        </svg>
-                    </div>
-                    <h2 className="text-2xl font-semibold text-black">{tFlashcardLearning('greatJob')}</h2>
-                    <p className="text-gray-700 max-w-md">{tFlashcardLearning('flashcardsCompleted')}</p>
+    // if (flashcards.length === 0 || !currentFlashcard) {
+    //     return (
+    //         <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+    //             <div className="text-center space-y-4">
+    //                 <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center border border-gray-200">
+    //                     <svg className="w-8 h-8 text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    //                         <path
+    //                             strokeLinecap="round"
+    //                             strokeLinejoin="round"
+    //                             strokeWidth={2}
+    //                             d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+    //                         />
+    //                     </svg>
+    //                 </div>
+    //                 <h2 className="text-2xl font-semibold text-black">{tFlashcardLearning('greatJob')}</h2>
+    //                 <p className="text-gray-700 max-w-md">{tFlashcardLearning('flashcardsCompleted')}</p>
+    //                 <div className="pt-4">
+    //                     <Button
+    //                         onClick={handleBackClick}
+    //                         className="px-6 py-2 mx-10 rounded-lg transition-colors border border-gray-300"
+    //                     >
+    //                         {tCommon('actions.back')}
+    //                     </Button>
+
+    //                     <Button
+    //                         onClick={handleRedirectFeynmanPage}
+    //                         className="px-6 py-2  rounded-lg transition-colors border border-gray-300"
+    //                     >
+    //                         {tFlashcardLearning('reviewKnowledge')}
+    //                     </Button>
+    //                 </div>
+    //             </div>
+    //         </div>
+    //     );
+    // }
+    // Handlers for prompt 100%
+    const onConfirmOnlySecond = async () => {
+        const { onlySecond } = q.getFullRanges();
+        const cards = studied.slice(onlySecond.start, onlySecond.end);
+        await q.startFullOnlySecond(cards);
+    };
+
+    const onConfirmCatchUpAll = async () => {
+        const { catchUpAll } = q.getFullRanges();
+        const cards = studied.slice(catchUpAll.start, catchUpAll.end);
+        await q.startFullCatchUpAll(cards);
+    };
+
+    const onSkipFull = () => {
+        const { onlySecond } = q.getFullRanges();
+        const cards = studied.slice(onlySecond.start, onlySecond.end);
+        q.skipFullQuiz(cards);
+    };
+
+    return (
+        <>
+            {/* Backlog banner */}
+            {q.backlogCount > 0 && (
+              <BacklogCTA count={q.backlogCount} onClick={q.startBacklogQuiz} />
+            )}
+
+            {/* main content */}
+            {flashcards.length === 0 || !currentFlashcard ? (
+                <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+                    <div className="text-center space-y-4">
+                        <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center border border-gray-200">
+                            <svg
+                                className="w-8 h-8 text-gray-800"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                                />
+                            </svg>
+                        </div>
+                        <h2 className="text-2xl font-semibold text-black">{tFlashcardLearning('greatJob')}</h2>
+                        <p className="text-gray-700 max-w-md">{tFlashcardLearning('flashcardsCompleted')}</p>
                     <div className="pt-4">
                         <Button
                             onClick={handleBackClick}
@@ -369,13 +406,9 @@ export default function Page() {
                             {tFlashcardLearning('reviewKnowledge')}
                         </Button>
                     </div>
+                    </div>
                 </div>
-            </div>
-        );
-    }
-
-    return (
-        <>
+            ) : (
             <FlashcardLearning
                 topicName={currentFlashcard.topicName ? currentFlashcard.topicName : ''}
                 total={flashcards.length}
@@ -388,12 +421,24 @@ export default function Page() {
                 handleLearningOptionClick={handleReviewFlashcardClick}
                 flashcardStatusCounts={flashcardStatusCounts}
             />
+            )}
 
-            {isGenerating && (
+            {q.isGenerating && (
                 <div className="fixed inset-0 z-[60] bg-black/30 backdrop-blur-sm flex items-center justify-center">
                     <div className="rounded-xl bg-white px-6 py-5 shadow-lg">Generating quiz…</div>
                 </div>
             )}
+
+            <QuickQuizPrompt
+                open={q.promptOpen}
+                variant={q.promptVariant}
+                percentLabel={q.percentLabel}
+                showCatchUp={q.showCatchUp}
+                onConfirmHalf={q.confirmHalfQuiz}
+                onConfirmOnlySecond={onConfirmOnlySecond}
+                onConfirmCatchUpAll={onConfirmCatchUpAll}
+                onSkip={q.promptVariant === 'half' ? q.skipHalfQuiz : onSkipFull}
+            />
         </>
     );
 }

--- a/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
+++ b/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
@@ -117,7 +117,7 @@ export default function Page() {
                 setFlashcardsStatusCounts(counter);
                 firstToFetchFlashcards.current = false;
             }
-            q.ensureBaseline(flashcards.length);
+            q.ensureBaseline(flashcards.length, flashcards.map(toQuizCard));
         }
     }, [flashcards]);
 
@@ -309,42 +309,6 @@ export default function Page() {
         return <LoadingPage />;
     }
 
-    // if (flashcards.length === 0 || !currentFlashcard) {
-    //     return (
-    //         <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
-    //             <div className="text-center space-y-4">
-    //                 <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center border border-gray-200">
-    //                     <svg className="w-8 h-8 text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    //                         <path
-    //                             strokeLinecap="round"
-    //                             strokeLinejoin="round"
-    //                             strokeWidth={2}
-    //                             d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-    //                         />
-    //                     </svg>
-    //                 </div>
-    //                 <h2 className="text-2xl font-semibold text-black">{tFlashcardLearning('greatJob')}</h2>
-    //                 <p className="text-gray-700 max-w-md">{tFlashcardLearning('flashcardsCompleted')}</p>
-    //                 <div className="pt-4">
-    //                     <Button
-    //                         onClick={handleBackClick}
-    //                         className="px-6 py-2 mx-10 rounded-lg transition-colors border border-gray-300"
-    //                     >
-    //                         {tCommon('actions.back')}
-    //                     </Button>
-
-    //                     <Button
-    //                         onClick={handleRedirectFeynmanPage}
-    //                         className="px-6 py-2  rounded-lg transition-colors border border-gray-300"
-    //                     >
-    //                         {tFlashcardLearning('reviewKnowledge')}
-    //                     </Button>
-    //                 </div>
-    //             </div>
-    //         </div>
-    //     );
-    // }
-    // Handlers for prompt 100%
     const onConfirmOnlySecond = async () => {
         const { onlySecond } = q.getFullRanges();
         const cards = studied.slice(onlySecond.start, onlySecond.end);

--- a/src/app/[locale]/flashcards/learning/components/BacklogCTA.tsx
+++ b/src/app/[locale]/flashcards/learning/components/BacklogCTA.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Sparkles } from 'lucide-react';
+
+type Props = {
+  count: number;             
+  onClick: () => void;       
+  className?: string;
+  labelOverride?: string;   
+  ctaText?: string;         
+};
+
+export default function BacklogCTA({
+  count,
+  onClick,
+  className,
+  labelOverride,
+  ctaText = 'Catch up',
+}: Props) {
+  if (count <= 0) return null;
+
+  const unit = count === 1 ? 'deferred card' : 'deferred cards';
+  const label = labelOverride ?? unit;
+
+  return (
+    <div className={`fixed top-4 right-4 z-[65] pointer-events-none ${className ?? ''}`}>
+      <motion.button
+        type="button"
+        initial={{ opacity: 0, y: -8, scale: 0.98 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ type: 'spring', stiffness: 280, damping: 22 }}
+        onClick={onClick}
+        className="group relative pointer-events-auto rounded-2xl p-[1px]
+                   shadow-[0_12px_40px_-16px_rgba(67,56,202,0.45)]
+                   hover:shadow-[0_16px_50px_-14px_rgba(59,130,246,0.55)]
+                   focus:outline-none"
+        aria-label="Catch up deferred cards"
+      >
+        {/* Galaxy rim */}
+        <div
+          className="absolute inset-0 rounded-2xl opacity-90 blur-[1px]"
+          style={{
+            background:
+              'conic-gradient(from 0deg at 50% 50%, #38bdf8, #a78bfa, #f472b6, #38bdf8)',
+          }}
+        />
+
+        {/* Glass chip */}
+        <div className="relative flex items-center gap-2 rounded-2xl
+                        bg-white/90 dark:bg-slate-950/75 backdrop-blur-xl
+                        ring-1 ring-white/30 dark:ring-sky-400/20
+                        px-3.5 py-2">
+          {/* tiny stars */}
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 rounded-2xl opacity-45 mix-blend-screen"
+            style={{
+              backgroundImage: `
+                radial-gradient(2px 2px at 20% 30%, rgba(255,255,255,.7), transparent 60%),
+                radial-gradient(1.6px 1.6px at 78% 42%, rgba(255,255,255,.55), transparent 60%),
+                radial-gradient(1.8px 1.8px at 42% 78%, rgba(255,255,255,.5), transparent 60%),
+                radial-gradient(1.4px 1.4px at 65% 20%, rgba(255,255,255,.45), transparent 60%)
+              `,
+            }}
+          />
+
+          <Sparkles className="h-[15px] w-[15px] text-sky-500 drop-shadow-[0_0_10px_rgba(56,189,248,0.65)]" />
+          <span className="text-[13px] leading-none font-medium text-slate-800 dark:text-sky-100">
+            You have <span className="font-bold">{count}</span> {label}
+          </span>
+
+          {/* CTA chip */}
+          <span
+            className="ml-1 rounded-full bg-gradient-to-r
+                       from-sky-500 via-fuchsia-500 to-indigo-500
+                       px-2 py-[3px] text-[11px] font-semibold text-white shadow-sm
+                       group-hover:brightness-110"
+          >
+            {ctaText}
+          </span>
+        </div>
+      </motion.button>
+    </div>
+  );
+}

--- a/src/app/[locale]/flashcards/learning/components/FlashcardLearning.tsx
+++ b/src/app/[locale]/flashcards/learning/components/FlashcardLearning.tsx
@@ -84,25 +84,28 @@ export function FlashcardLearning({
                     {shouldShowTrackingOptions ? (
                         <div className="grid grid-cols-12 gap-6 mt-4 w-[55%] h-[18%]">
                             {learningOptions.map((option, index) => {
-                                const nextReviewSchedule = flashcard.nextReviewSchedule;
-                                const nextReviewIntervalForRating =
-                                    nextReviewSchedule.nextReviewIntervalsForRating.find(
-                                        (e) => e.rating === option.rating,
-                                    );
-                                if (!nextReviewIntervalForRating) {
-                                    return <>Rating not found</>;
-                                }
-                                const intervalFormatted = flashcardHelper.formatInterval(
-                                    nextReviewIntervalForRating.interval,
-                                );
+                                // const nextReviewInterval = flashcard?.qualityResponsesNextReviewInterval.find(
+                                //     (element) => element.qualityResponse === option.qualityResponse,
+                                // )?.nextReviewInterval;
+                                // Get the interval list if available, otherwise the array is empty
+                                const intervals = flashcard.nextReviewSchedule?.nextReviewIntervalsForRating ?? [];
+
+                                // Find interval by current rating (can be undefined)
+                                const found = intervals.find((i) => i.rating === option.rating);
+                                const interval = found?.interval;
+
+                                // Display label: if data is missing, use a dash
+                                const intervalFormatted = interval ? flashcardHelper.formatInterval(interval) : '—';
 
                                 return (
                                     <TooltipProvider key={index}>
                                         <Tooltip>
                                             <TooltipTrigger asChild>
                                                 <div
-                                                    className="col-span-3 h-full flex flex-col gap-0 justify-center items-center rounded-lg bg-white dark:bg-gray-700 cursor-pointer"
+                                                    className="col-span-3 h-full flex flex-col gap-0 justify-center items-center rounded-lg
+                   bg-white dark:bg-gray-700 cursor-pointer"
                                                     onClick={() => handleLearningOptionClick(option.rating)}
+                                                    aria-disabled={!interval}
                                                 >
                                                     {option.icon}
                                                     <Label className="text-lg">{option.label}</Label>
@@ -111,7 +114,7 @@ export function FlashcardLearning({
                                                     </Label>
                                                 </div>
                                             </TooltipTrigger>
-                                            <TooltipContent>Key shortcut: {option.rating} </TooltipContent>
+                                            <TooltipContent>Key shortcut: {option.rating}</TooltipContent>
                                         </Tooltip>
                                     </TooltipProvider>
                                 );

--- a/src/app/[locale]/flashcards/learning/components/QuickQuizPrompt.tsx
+++ b/src/app/[locale]/flashcards/learning/components/QuickQuizPrompt.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { Button } from '@/components/ui/button';
+import { Sparkles } from 'lucide-react';
+
+type Variant = 'half' | 'full';
+
+type Props = {
+  open: boolean;
+  variant: Variant;
+  percentLabel: number;         
+  showCatchUp?: boolean;         
+  onConfirmHalf?: () => void;    // half
+  onConfirmOnlySecond?: () => void; // full 
+  onConfirmCatchUpAll?: () => void; // full
+  onSkip: () => void;
+};
+
+export default function QuickQuizPrompt({
+  open,
+  variant,
+  percentLabel,
+  showCatchUp = true,
+  onConfirmHalf,
+  onConfirmOnlySecond,
+  onConfirmCatchUpAll,
+  onSkip,
+}: Props) {
+  const isHalf = variant === 'half';
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed top-4 inset-x-0 z-[70] flex justify-center pointer-events-none">
+          <motion.div
+            initial={{ y: -100, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: -100, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 24 }}
+            className="pointer-events-auto w-[min(720px,92vw)]"
+          >
+            <div className="rounded-2xl p-[1px] bg-gradient-to-r from-sky-500/50 via-indigo-500/50 to-blue-500/50 shadow-xl dark:shadow-[0_10px_40px_-10px_rgba(59,130,246,0.45)]">
+              <div className="rounded-2xl backdrop-blur-xl ring-1 ring-sky-600/15 dark:ring-sky-400/25 bg-white/95 dark:bg-gradient-to-br dark:from-slate-950/90 dark:via-indigo-950/80 dark:to-sky-950/80">
+                <div className="px-6 py-5">
+                  <div className="flex items-center gap-3">
+                    <Sparkles className="h-5 w-5 text-sky-600 dark:text-sky-300 dark:drop-shadow-[0_0_12px_rgba(56,189,248,0.55)]" />
+                    <div className="font-extrabold tracking-tight text-slate-900 dark:text-sky-100">
+                      {isHalf ? (
+                        <>You’ve completed {percentLabel}% of the content</>
+                      ) : (
+                        <>You’ve completed {percentLabel}% of the content</>
+                      )}
+                    </div>
+                  </div>
+
+                  <p className="mt-2 text-[15px] leading-6 text-slate-700 dark:text-sky-200/85">
+                    {isHalf
+                      ? 'Create a quick quiz based on what you just learned?'
+                      : (showCatchUp
+                          ? 'Choose what to quiz now: only the new half, or everything you’ve learned so far.'
+                          : 'Create a quick quiz for the remaining half?')}
+                  </p>
+
+                  <div className="mt-4 flex flex-wrap items-center gap-3">
+                    {isHalf ? (
+                      <>
+                        <Button
+                          size="sm"
+                          onClick={onConfirmHalf}
+                          className="bg-gradient-to-r from-sky-500 via-indigo-500 to-violet-500 text-white shadow-lg hover:brightness-110 hover:shadow-[0_12px_40px_-12px_rgba(56,189,248,0.6)] focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 ring-offset-white dark:ring-offset-slate-950"
+                        >
+                          Take quiz
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={onSkip}
+                          className="border-sky-600/30 text-sky-700 hover:bg-sky-50 dark:border-sky-400/40 dark:text-sky-200 dark:hover:bg-sky-400/10"
+                        >
+                          Later
+                        </Button>
+                      </>
+                    ) : (
+                      <>
+                        {showCatchUp ? (
+                          <>
+                            <Button
+                              size="sm"
+                              onClick={onConfirmCatchUpAll}
+                              className="bg-gradient-to-r from-sky-500 via-indigo-500 to-violet-500 text-white shadow-lg hover:brightness-110 hover:shadow-[0_12px_40px_-12px_rgba(56,189,248,0.6)] focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 ring-offset-white dark:ring-offset-slate-950"
+                            >
+                              Quiz everything so far
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={onConfirmOnlySecond}
+                              className="border-sky-600/30 text-sky-700 hover:bg-sky-50 dark:border-sky-400/40 dark:text-sky-200 dark:hover:bg-sky-400/10"
+                            >
+                              Only the new half
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={onSkip}
+                              className="text-sky-700 hover:bg-sky-50 dark:text-sky-300 dark:hover:bg-sky-400/10"
+                            >
+                              Later
+                            </Button>
+                          </>
+                        ) : (
+                          <>
+                            <Button
+                              size="sm"
+                              onClick={onConfirmOnlySecond}
+                              className="bg-gradient-to-r from-sky-500 via-indigo-500 to-violet-500 text-white shadow-lg hover:brightness-110 hover:shadow-[0_12px_40px_-12px_rgba(56,189,248,0.6)] focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 ring-offset-white dark:ring-offset-slate-950"
+                            >
+                              Take quiz (remaining half)
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={onSkip}
+                              className="border-sky-600/30 text-sky-700 hover:bg-sky-50 dark:border-sky-400/40 dark:text-sky-200 dark:hover:bg-sky-400/10"
+                            >
+                              Later
+                            </Button>
+                          </>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/app/[locale]/flashcards/learning/hooks/useQuizMilestones.ts
+++ b/src/app/[locale]/flashcards/learning/hooks/useQuizMilestones.ts
@@ -8,11 +8,11 @@ import { writeLocalQuiz } from '@/app/[locale]/quiz/utils/localQuiz.storage';
 import { buildPayloadFromLearnedFlashcards } from '@/app/[locale]/question/utils/buildGenPayload';
 
 export type QuizCard = {
-  flashcardId: number | string;
-  front: string;
-  back: string;
-  imageUrl?: string | null;
-  topicName?: string | null;
+    flashcardId: number | string;
+    front: string;
+    back: string;
+    imageUrl?: string | null;
+    topicName?: string | null;
 };
 
 type HalfStatus = 'pending' | 'quizzed' | 'deferred';
@@ -20,30 +20,30 @@ type PromptVariant = 'half' | 'full';
 type PendingAction = 'half' | 'onlySecond' | 'catchUpAll' | 'backlog' | null;
 
 type UseQuizMilestonesParams = {
-  topicId: string;
-  regenerate: (payload: any, type: 'quiz') => Promise<void>;
-  sseData: any;
-  sseStatus: string;          
-  loading: boolean;           
-  chunkRatio?: number;     
+    topicId: string;
+    regenerate: (payload: any, type: 'quiz') => Promise<void>;
+    sseData: any;
+    sseStatus: string;
+    loading: boolean;
+    chunkRatio?: number;
 };
 
 /* ---------- localStorage helpers ---------- */
-const keyBaseline      = (topicId: string) => `progressive_quiz_baseline_total:${topicId}`;
+const keyBaseline = (topicId: string) => `progressive_quiz_baseline_total:${topicId}`;
 const keyLastRemaining = (topicId: string) => `progressive_quiz_last_remaining:${topicId}`;
-const keyHalf          = (topicId: string, which: 'first'|'second') => `progressive_quiz_half_status:${topicId}:${which}`;
-const keyBacklog       = (topicId: string) => `progressive_quiz_backlog:${topicId}`;
-const keyPendingFirst  = (topicId: string) => `progressive_quiz_pending_first:${topicId}`;
+const keyHalf = (topicId: string, which: 'first' | 'second') => `progressive_quiz_half_status:${topicId}:${which}`;
+const keyBacklog = (topicId: string) => `progressive_quiz_backlog:${topicId}`;
+const keyPendingFirst = (topicId: string) => `progressive_quiz_pending_first:${topicId}`;
 
 const readNum = (key: string, def = 0) => {
-  if (typeof window === 'undefined') return def;
-  const raw = window.localStorage.getItem(key);
-  const n = raw ? parseInt(raw, 10) : def;
-  return Number.isFinite(n) ? n : def;
+    if (typeof window === 'undefined') return def;
+    const raw = window.localStorage.getItem(key);
+    const n = raw ? parseInt(raw, 10) : def;
+    return Number.isFinite(n) ? n : def;
 };
 const writeNum = (key: string, n: number) => {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(key, String(n));
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(key, String(n));
 };
 
 const readBaseline = (topicId: string) => readNum(keyBaseline(topicId), 0);
@@ -52,366 +52,408 @@ const writeBaseline = (topicId: string, n: number) => writeNum(keyBaseline(topic
 const readLastRemaining = (topicId: string) => readNum(keyLastRemaining(topicId), 0);
 const writeLastRemaining = (topicId: string, n: number) => writeNum(keyLastRemaining(topicId), n);
 
-const loadStatus = (topicId: string, which: 'first'|'second'): HalfStatus => {
-  if (typeof window === 'undefined') return 'pending';
-  const raw = window.localStorage.getItem(keyHalf(topicId, which));
-  return (raw as HalfStatus) || 'pending';
+const loadStatus = (topicId: string, which: 'first' | 'second'): HalfStatus => {
+    if (typeof window === 'undefined') return 'pending';
+    const raw = window.localStorage.getItem(keyHalf(topicId, which));
+    return (raw as HalfStatus) || 'pending';
 };
-const saveStatus = (topicId: string, which: 'first'|'second', val: HalfStatus) => {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(keyHalf(topicId, which), val);
+const saveStatus = (topicId: string, which: 'first' | 'second', val: HalfStatus) => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(keyHalf(topicId, which), val);
 };
 
 /* ---------- Backlog & pending-first helpers ---------- */
 const readBacklog = (topicId: string): QuizCard[] => {
-  if (typeof window === 'undefined') return [];
-  const raw = window.localStorage.getItem(keyBacklog(topicId));
-  if (!raw) return [];
-  try { return JSON.parse(raw) as QuizCard[]; } catch { return []; }
+    if (typeof window === 'undefined') return [];
+    const raw = window.localStorage.getItem(keyBacklog(topicId));
+    if (!raw) return [];
+    try {
+        return JSON.parse(raw) as QuizCard[];
+    } catch {
+        return [];
+    }
 };
 const writeBacklog = (topicId: string, cards: QuizCard[]) => {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(keyBacklog(topicId), JSON.stringify(cards));
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(keyBacklog(topicId), JSON.stringify(cards));
 };
 
 const readPendingFirst = (topicId: string): QuizCard[] => {
-  if (typeof window === 'undefined') return [];
-  const raw = window.localStorage.getItem(keyPendingFirst(topicId));
-  if (!raw) return [];
-  try { return JSON.parse(raw) as QuizCard[]; } catch { return []; }
+    if (typeof window === 'undefined') return [];
+    const raw = window.localStorage.getItem(keyPendingFirst(topicId));
+    if (!raw) return [];
+    try {
+        return JSON.parse(raw) as QuizCard[];
+    } catch {
+        return [];
+    }
 };
 const writePendingFirst = (topicId: string, cards: QuizCard[]) => {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(keyPendingFirst(topicId), JSON.stringify(cards));
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(keyPendingFirst(topicId), JSON.stringify(cards));
 };
 const clearPendingFirst = (topicId: string) => {
-  if (typeof window === 'undefined') return;
-  window.localStorage.removeItem(keyPendingFirst(topicId));
+    if (typeof window === 'undefined') return;
+    window.localStorage.removeItem(keyPendingFirst(topicId));
 };
 
 const dedupeById = (arr: QuizCard[]) => {
-  const seen = new Set<string>();
-  return arr.filter(c => {
-    const id = String(c.flashcardId);
-    if (seen.has(id)) return false;
-    seen.add(id);
-    return true;
-  });
+    const seen = new Set<string>();
+    return arr.filter((c) => {
+        const id = String(c.flashcardId);
+        if (seen.has(id)) return false;
+        seen.add(id);
+        return true;
+    });
 };
 
 /* ---------- Standardize QuizCard -> builder type needed ---------- */
 type DueCardLike = {
-  flashcardId: number;
-  front: string;
-  back: string;
-  imageUrl?: string | null;
-  topicName?: string | null;
+    flashcardId: number;
+    front: string;
+    back: string;
+    imageUrl?: string | null;
+    topicName?: string | null;
 };
 
 const normalizeToDue = (c: QuizCard): DueCardLike => ({
-  flashcardId: typeof c.flashcardId === 'string' ? Number(c.flashcardId) : c.flashcardId,
-  front: c.front,
-  back: c.back,
-  imageUrl: c.imageUrl ?? null,
-  topicName: c.topicName ?? null,
+    flashcardId: typeof c.flashcardId === 'string' ? Number(c.flashcardId) : c.flashcardId,
+    front: c.front,
+    back: c.back,
+    imageUrl: c.imageUrl ?? null,
+    topicName: c.topicName ?? null,
 });
 
 /** Always use this helper instead of calling the builder directly to avoid type errors */
 const buildPayloadFromQuizCards = (topicId: string, cards: QuizCard[]) => {
-  const normalized = cards.map(normalizeToDue);
-  return buildPayloadFromLearnedFlashcards(topicId, normalized as any);
+    const normalized = cards.map(normalizeToDue);
+    return buildPayloadFromLearnedFlashcards(topicId, normalized as any);
 };
 
 export function useQuizMilestones({
-  topicId,
-  regenerate,
-  sseData,
-  sseStatus,
-  loading,
-  chunkRatio = 0.5,
+    topicId,
+    regenerate,
+    sseData,
+    sseStatus,
+    loading,
+    chunkRatio = 0.5,
 }: UseQuizMilestonesParams) {
-  const router = useRouter();
-  const [sessionEpoch, setSessionEpoch] = useState<number>(0);
+    const router = useRouter();
+    const [sessionEpoch, setSessionEpoch] = useState<number>(0);
 
-  // Baseline (persisted): “fixed” total of the session
-  const [baselineTotal, setBaselineTotal] = useState<number>(() => readBaseline(topicId));
-  const [lastRemaining, setLastRemaining] = useState<number>(() => readLastRemaining(topicId));
+    // Baseline (persisted): “fixed” total of the session
+    const [baselineTotal, setBaselineTotal] = useState<number>(() => readBaseline(topicId));
+    const [lastRemaining, setLastRemaining] = useState<number>(() => readLastRemaining(topicId));
 
-  // Persisted state
-  const [firstHalfStatus, setFirstHalfStatus]   = useState<HalfStatus>(() => loadStatus(topicId, 'first'));
-  const [secondHalfStatus, setSecondHalfStatus] = useState<HalfStatus>(() => loadStatus(topicId, 'second'));
+    // Persisted state
+    const [firstHalfStatus, setFirstHalfStatus] = useState<HalfStatus>(() => loadStatus(topicId, 'first'));
+    const [secondHalfStatus, setSecondHalfStatus] = useState<HalfStatus>(() => loadStatus(topicId, 'second'));
 
-  // Backlog (persisted)
-  const [backlogCount, setBacklogCount] = useState<number>(() => readBacklog(topicId).length);
+    // Backlog (persisted)
+    const [backlogCount, setBacklogCount] = useState<number>(() => readBacklog(topicId).length);
 
-  useEffect(() => { writeBaseline(topicId, baselineTotal); }, [topicId, baselineTotal]);
-  useEffect(() => { writeLastRemaining(topicId, lastRemaining); }, [topicId, lastRemaining]);
-  useEffect(() => saveStatus(topicId, 'first',  firstHalfStatus),  [topicId, firstHalfStatus]);
-  useEffect(() => saveStatus(topicId, 'second', secondHalfStatus), [topicId, secondHalfStatus]);
+    useEffect(() => {
+        writeBaseline(topicId, baselineTotal);
+    }, [topicId, baselineTotal]);
+    useEffect(() => {
+        writeLastRemaining(topicId, lastRemaining);
+    }, [topicId, lastRemaining]);
+    useEffect(() => saveStatus(topicId, 'first', firstHalfStatus), [topicId, firstHalfStatus]);
+    useEffect(() => saveStatus(topicId, 'second', secondHalfStatus), [topicId, secondHalfStatus]);
 
-  // UI Prompt
-  const [promptOpen, setPromptOpen] = useState(false);
-  const [promptVariant, setPromptVariant] = useState<PromptVariant>('half');
+    // UI Prompt
+    const [promptOpen, setPromptOpen] = useState(false);
+    const [promptVariant, setPromptVariant] = useState<PromptVariant>('half');
 
-  // Show Catch-up option at 100% if first half is not quizzed
-  const showCatchUp = useMemo(() => firstHalfStatus !== 'quizzed', [firstHalfStatus]);
+    // Show Catch-up option at 100% if first half is not quizzed
+    const showCatchUp = useMemo(() => firstHalfStatus !== 'quizzed', [firstHalfStatus]);
 
-  // Queue chunk/cards when user confirm
-  const [queuedChunkCards, setQueuedChunkCards] = useState<QuizCard[] | null>(null);
-  const [queuedChunkNumber, setQueuedChunkNumber] = useState<number | null>(null); // 1: 50%, 2: 100%
+    // Queue chunk/cards when user confirm
+    const [queuedChunkCards, setQueuedChunkCards] = useState<QuizCard[] | null>(null);
+    const [queuedChunkNumber, setQueuedChunkNumber] = useState<number | null>(null); // 1: 50%, 2: 100%
 
-  // Monitor the generating action to update the state correctly when SSE is finished
-  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
-  const [pendingChunk, setPendingChunk] = useState<number | null>(null);
+    // Monitor the generating action to update the state correctly when SSE is finished
+    const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+    const [pendingChunk, setPendingChunk] = useState<number | null>(null);
 
-  // Milestones theo baseline
-  const [t50, t100] = useMemo(() => {
-    if (baselineTotal <= 0) return [0, 0] as const;
-    const half = Math.ceil(baselineTotal * chunkRatio);
-    return [half, baselineTotal] as const;
-  }, [baselineTotal, chunkRatio]);
+    // Milestones theo baseline
+    const [t50, t100] = useMemo(() => {
+        if (baselineTotal <= 0) return [0, 0] as const;
+        const half = Math.ceil(baselineTotal * chunkRatio);
+        return [half, baselineTotal] as const;
+    }, [baselineTotal, chunkRatio]);
 
-  const percentLabel = promptVariant === 'half' ? Math.round(chunkRatio * 100) : 100;
-  const isGenerating = pendingChunk !== null && (loading || sseStatus === 'open');
+    const percentLabel = promptVariant === 'half' ? Math.round(chunkRatio * 100) : 100;
+    const isGenerating = pendingChunk !== null && (loading || sseStatus === 'open');
 
-  /* ---------- session helpers ---------- */
-  const closeSession = () => {
-    setBaselineTotal(0);
-    setFirstHalfStatus('pending');
-    setSecondHalfStatus('pending');
-    setPromptOpen(false);
-    setQueuedChunkCards(null);
-    setQueuedChunkNumber(null);
-    setLastRemaining(0);
-    setSessionEpoch((x) => x + 1); // increase epoch at session close
-  };
+    /* ---------- session helpers ---------- */
+    const closeSession = () => {
+        setBaselineTotal(0);
+        setFirstHalfStatus('pending');
+        setSecondHalfStatus('pending');
+        setPromptOpen(false);
+        setQueuedChunkCards(null);
+        setQueuedChunkNumber(null);
+        setLastRemaining(0);
+        setBaselineOrder([]);
+        setSessionEpoch((x) => x + 1); // increase epoch at session close
+    };
 
-  /* ---------- Backlog API ---------- */
-  const appendToBacklog = (cards: QuizCard[]) => {
-    if (!cards?.length) return;
-    const cur = readBacklog(topicId);
-    const next = dedupeById([...cards, ...cur]); // newest first
-    writeBacklog(topicId, next);
-    setBacklogCount(next.length);
-  };
-  const clearBacklog = () => {
-    writeBacklog(topicId, []);
-    setBacklogCount(0);
-  };
-  const startBacklogQuiz = async () => {
-    if (isGenerating) return;
-    const cards = readBacklog(topicId);
-    if (cards.length === 0) return;
-    const payload = buildPayloadFromQuizCards(topicId, cards);
-    setPendingChunk(3);                // 3 = type "backlog"
-    setPendingAction('backlog');
-    setPromptOpen(false);
-    await regenerate(payload, 'quiz');
-  };
+    /* ---------- Backlog API ---------- */
+    const appendToBacklog = (cards: QuizCard[]) => {
+        if (!cards?.length) return;
+        const cur = readBacklog(topicId);
+        const next = dedupeById([...cards, ...cur]); // newest first
+        writeBacklog(topicId, next);
+        setBacklogCount(next.length);
+    };
+    const clearBacklog = () => {
+        writeBacklog(topicId, []);
+        setBacklogCount(0);
+    };
+    const startBacklogQuiz = async () => {
+        if (isGenerating) return;
+        const cards = readBacklog(topicId);
+        if (cards.length === 0) return;
+        const payload = buildPayloadFromQuizCards(topicId, cards);
+        setPendingChunk(3); // 3 = type "backlog"
+        setPendingAction('backlog');
+        setPromptOpen(false);
+        await regenerate(payload, 'quiz');
+    };
 
-  /* ---------- API for Page: fix/reset baseline ---------- */
-  const ensureBaseline = (currentRemainingCount: number) => {
-    if (currentRemainingCount < 0) return;
+    /* ---------- API for Page: fix/reset baseline ---------- */
+    const [baselineOrder, setBaselineOrder] = useState<QuizCard[]>([]);
+    const ensureBaseline = (currentRemainingCount: number, baselineCards?: QuizCard[]) => {
+        if (currentRemainingCount < 0) return;
+        setLastRemaining(currentRemainingCount);
+        if (currentRemainingCount === 0) return;
 
-    setLastRemaining(currentRemainingCount); // monitor for increases
+        const resetTo = () => {
+            setBaselineTotal(currentRemainingCount);
+            setFirstHalfStatus('pending');
+            setSecondHalfStatus('pending');
+            setPromptOpen(false);
+            setQueuedChunkCards(null);
+            setQueuedChunkNumber(null);
+            // lock baseline order if provided
+            setBaselineOrder(baselineCards ? dedupeById(baselineCards) : []);
+            setSessionEpoch((x) => x + 1);
+        };
 
-    if (currentRemainingCount === 0) return;
+        if (baselineTotal === 0) {
+            resetTo();
+            return;
+        }
+        if (currentRemainingCount > baselineTotal || currentRemainingCount > lastRemaining) {
+            const pf = readPendingFirst(topicId);
+            if (pf.length) {
+                appendToBacklog(pf);
+                clearPendingFirst(topicId);
+            }
+            resetTo();
+        }
+    };
 
-    if (baselineTotal === 0) {
-      setBaselineTotal(currentRemainingCount);
-      setFirstHalfStatus('pending');
-      setSecondHalfStatus('pending');
-      setSessionEpoch((x) => x + 1); // open a new session
-      return;
-    }
+    /* ---------- API for Page: progress after each review ---------- */
+    const onStudiedProgress = (studied: QuizCard[], currentRemainingCount: number) => {
+        if (!baselineTotal || isGenerating || promptOpen) return;
 
-    if (currentRemainingCount > baselineTotal || currentRemainingCount > lastRemaining) {
-      // Start new session: if old session kept pending-first then move to backlog
-      const pf = readPendingFirst(topicId);
-      if (pf.length) {
-        appendToBacklog(pf);
+        setLastRemaining(currentRemainingCount);
+
+        const studiedSoFar = baselineTotal - currentRemainingCount;
+
+        // 50% if first half is pending
+        if (t50 > 0 && studiedSoFar >= t50 && firstHalfStatus === 'pending') {
+            const hasBaseline = baselineOrder.length >= t50;
+            const firstSlice = dedupeById((hasBaseline ? baselineOrder : studied).slice(0, t50));
+            if (firstSlice.length === 0) return;
+
+            setQueuedChunkCards(firstSlice);
+            setQueuedChunkNumber(1);
+            setPromptVariant('half');
+            setPromptOpen(true);
+            return;
+        }
+
+        // 100% if the second half is pending
+        if (t100 > 0 && studiedSoFar >= t100 && secondHalfStatus === 'pending') {
+            setQueuedChunkCards(null); // full: let Page slice
+            setQueuedChunkNumber(2);
+            setPromptVariant('full');
+            setPromptOpen(true);
+        }
+    };
+
+    /* ---------- 50% actions ---------- */
+    const confirmHalfQuiz = async () => {
+        if (queuedChunkNumber !== 1 || !queuedChunkCards?.length) {
+            setPromptOpen(false);
+            return;
+        }
+        const payload = buildPayloadFromQuizCards(topicId, queuedChunkCards);
+        setPendingChunk(1);
+        setPendingAction('half');
+        setPromptOpen(false);
+        setQueuedChunkCards(null);
+        setQueuedChunkNumber(null);
+        await regenerate(payload, 'quiz');
+    };
+
+    const skipHalfQuiz = () => {
+        if (queuedChunkNumber === 1 && queuedChunkCards?.length) {
+            writePendingFirst(topicId, dedupeById(queuedChunkCards));
+        }
+        setFirstHalfStatus('deferred');
+        setPromptOpen(false);
+        setQueuedChunkCards(null);
+        setQueuedChunkNumber(null);
+    };
+
+    /* ---------- 100% actions ---------- */
+    const getFullRanges = () => ({
+        onlySecond: { start: Math.max(0, t50), end: t100 }, // [t50, t100)
+        catchUpAll: { start: 0, end: t100 }, // [0, t100)
+    });
+
+    // Only second: backlog first half (if Later), quiz second half
+    const startFullOnlySecond = async (cards: QuizCard[]) => {
+        if (!cards?.length) {
+            setPromptOpen(false);
+            return;
+        }
+
+        if (firstHalfStatus === 'deferred') {
+            const pf = readPendingFirst(topicId);
+            if (pf.length) appendToBacklog(pf);
+            clearPendingFirst(topicId);
+        }
+
+        const payload = buildPayloadFromQuizCards(topicId, cards);
+        setPendingChunk(2);
+        setPendingAction('onlySecond');
+        setPromptOpen(false);
+        await regenerate(payload, 'quiz');
+    };
+
+    // Catch-up all: quiz both halves, clear pending-first
+    const startFullCatchUpAll = async (cards: QuizCard[]) => {
+        if (!cards?.length) {
+            setPromptOpen(false);
+            return;
+        }
         clearPendingFirst(topicId);
-      }
-      setBaselineTotal(currentRemainingCount);
-      setFirstHalfStatus('pending');
-      setSecondHalfStatus('pending');
-      setPromptOpen(false);
-      setQueuedChunkCards(null);
-      setQueuedChunkNumber(null);
-      setSessionEpoch((x) => x + 1); // open a new session
-    }
-  };
+        const payload = buildPayloadFromQuizCards(topicId, cards);
+        setPendingChunk(2);
+        setPendingAction('catchUpAll');
+        setPromptOpen(false);
+        await regenerate(payload, 'quiz');
+    };
 
-  /* ---------- API for Page: progress after each review ---------- */
-  const onStudiedProgress = (
-    studied: QuizCard[],
-    currentRemainingCount: number
-  ) => {
-    if (!baselineTotal || isGenerating || promptOpen) return;
+    // Later at 100%: backlog second half + (if any) first half pending, then close session
 
-    setLastRemaining(currentRemainingCount);
+    const skipFullQuiz = (secondHalfCards: QuizCard[]) => {
+        // If parameter is empty, get from baselineOrder (make sure there is data)
+        let second = secondHalfCards;
+        if (!second?.length && baselineOrder.length >= t100) {
+            second = dedupeById(baselineOrder.slice(t50, t100));
+        }
 
-    const studiedSoFar = baselineTotal - currentRemainingCount;
+        if (second?.length) appendToBacklog(second);
 
-    // 50% if first half is pending
-    if (t50 > 0 && studiedSoFar >= t50 && firstHalfStatus === 'pending') {
-      const firstSlice = studied.length >= t50 ? studied.slice(0, t50) : studied.slice(); // safety
-      setQueuedChunkCards(firstSlice);
-      setQueuedChunkNumber(1);
-      setPromptVariant('half');
-      setPromptOpen(true);
-      return;
-    }
+        if (firstHalfStatus === 'deferred') {
+            const pf = readPendingFirst(topicId);
+            if (pf.length) appendToBacklog(pf);
+            clearPendingFirst(topicId);
+        }
 
-    // 100% if the second half is pending
-    if (t100 > 0 && studiedSoFar >= t100 && secondHalfStatus === 'pending') {
-      setQueuedChunkCards(null); // full: let Page slice
-      setQueuedChunkNumber(2);
-      setPromptVariant('full');
-      setPromptOpen(true);
-    }
-  };
+        // Force resync count from storage just before closing session
+        setBacklogCount(readBacklog(topicId).length);
 
-  /* ---------- 50% actions ---------- */
-  const confirmHalfQuiz = async () => {
-    if (queuedChunkNumber !== 1 || !queuedChunkCards?.length) {
-      setPromptOpen(false);
-      return;
-    }
-    const payload = buildPayloadFromQuizCards(topicId, queuedChunkCards);
-    setPendingChunk(1);
-    setPendingAction('half');
-    setPromptOpen(false);
-    setQueuedChunkCards(null);
-    setQueuedChunkNumber(null);
-    await regenerate(payload, 'quiz');
-  };
+        setSecondHalfStatus('deferred');
+        setPromptOpen(false);
+        setQueuedChunkCards(null);
+        setQueuedChunkNumber(null);
+        closeSession();
+    };
 
-  const skipHalfQuiz = () => {
-    // DO NOT push into backlog now — keep pending-first to decide at 100%
-    if (queuedChunkNumber === 1 && queuedChunkCards?.length) {
-      writePendingFirst(topicId, queuedChunkCards);
-    }
-    setFirstHalfStatus('deferred');
-    setPromptOpen(false);
-    setQueuedChunkCards(null);
-    setQueuedChunkNumber(null);
-  };
+    useEffect(() => {
+        // resynchronize backlog number every time session closes/opens
+        setBacklogCount(readBacklog(topicId).length);
+    }, [sessionEpoch, topicId]);
 
-  /* ---------- 100% actions ---------- */
-  const getFullRanges = () => ({
-    onlySecond: { start: Math.max(0, t50), end: t100 }, // [t50, t100)
-    catchUpAll: { start: 0, end: t100 },                // [0, t100)
-  });
+    /* ---------- SSE complete ---------- */
+    useEffect(() => {
+        if (pendingChunk === null) return;
 
-  // Only second: backlog first half (if Later), quiz second half
-  const startFullOnlySecond = async (cards: QuizCard[]) => {
-    if (!cards?.length) { setPromptOpen(false); return; }
+        const raw = (sseData as any)?.data?.data as IQuestionsFromSSERaw | undefined;
+        const payloadStatus = (sseData as any)?.data?.status ?? (sseData as any)?.status;
+        const terminal = new Set(['completed', 'closed', 'error', 'failed']);
+        const done = terminal.has(sseStatus) || terminal.has(payloadStatus);
+        if (!done) return;
 
-    if (firstHalfStatus === 'deferred') {
-      const pf = readPendingFirst(topicId);
-      if (pf.length) appendToBacklog(pf);
-      clearPendingFirst(topicId);
-    }
+        const hasQuestions = Array.isArray(raw) && raw.length > 0;
+        if (!hasQuestions) {
+            // Clear pending to avoid getting stuck
+            setPendingAction(null);
+            setPendingChunk(null);
+            setPromptOpen(false);
+            return; // // no navigation
+        }
 
-    const payload = buildPayloadFromQuizCards(topicId, cards);
-    setPendingChunk(2);
-    setPendingAction('onlySecond');
-    setPromptOpen(false);
-    await regenerate(payload, 'quiz');
-  };
+        const parsed = handleConvertToQuestionsEdited({ type: 'generative', questionsProp: raw });
+        const toStore = parsed.map((q) => ({
+            questionText: q.questionText,
+            choices: q.choices,
+            correctIndex: q.correctIndex,
+        }));
+        writeLocalQuiz(topicId, toStore);
 
-  // Catch-up all: quiz both halves, clear pending-first
-  const startFullCatchUpAll = async (cards: QuizCard[]) => {
-    if (!cards?.length) { setPromptOpen(false); return; }
-    clearPendingFirst(topicId);
-    const payload = buildPayloadFromQuizCards(topicId, cards);
-    setPendingChunk(2);
-    setPendingAction('catchUpAll');
-    setPromptOpen(false);
-    await regenerate(payload, 'quiz');
-  };
+        if (pendingAction === 'half') {
+            setFirstHalfStatus('quizzed'); // continue session
+        } else if (pendingAction === 'onlySecond') {
+            setSecondHalfStatus('quizzed'); // finished second half → close session
+            closeSession();
+        } else if (pendingAction === 'catchUpAll') {
+            setFirstHalfStatus('quizzed');
+            setSecondHalfStatus('quizzed'); // both done → close session
+            closeSession();
+        } else if (pendingAction === 'backlog') {
+            clearBacklog(); // quiz backlog done → clear
+        }
 
-  // Later at 100%: backlog second half + (if any) first half pending, then close session
-  const skipFullQuiz = (secondHalfCards: QuizCard[]) => {
-    if (secondHalfCards?.length) appendToBacklog(secondHalfCards);
+        const chunk = pendingChunk;
+        setPendingAction(null);
+        setPendingChunk(null);
+        router.push(`/quiz/local?topicId=${topicId}&chunk=${chunk}`);
+    }, [sseStatus, sseData, pendingChunk, pendingAction, topicId, router]);
 
-    if (firstHalfStatus === 'deferred') {
-      const pf = readPendingFirst(topicId);
-      if (pf.length) appendToBacklog(pf);
-      clearPendingFirst(topicId);
-    }
+    return {
+        // UI state
+        promptOpen,
+        promptVariant,
+        percentLabel,
+        isGenerating,
+        showCatchUp,
 
-    setSecondHalfStatus('deferred');
-    setPromptOpen(false);
-    setQueuedChunkCards(null);
-    setQueuedChunkNumber(null);
-    closeSession();
-  };
+        // HALF
+        confirmHalfQuiz,
+        skipHalfQuiz,
 
-  /* ---------- SSE complete ---------- */
-  useEffect(() => {
-    if (pendingChunk === null) return;
+        // FULL
+        getFullRanges,
+        startFullOnlySecond,
+        startFullCatchUpAll,
+        skipFullQuiz,
 
-    const raw = (sseData as any)?.data?.data as IQuestionsFromSSERaw | undefined;
-    const payloadStatus = (sseData as any)?.data?.status ?? (sseData as any)?.status;
-    const done = sseStatus === 'completed' || payloadStatus === 'completed';
-    if (!done) return;
-    if (!Array.isArray(raw) || raw.length === 0) return;
+        // Backlog
+        backlogCount,
+        startBacklogQuiz,
 
-    const parsed = handleConvertToQuestionsEdited({ type: 'generative', questionsProp: raw });
-    const toStore = parsed.map(q => ({
-      questionText: q.questionText,
-      choices: q.choices,
-      correctIndex: q.correctIndex,
-    }));
-    writeLocalQuiz(topicId, toStore);
+        // API for Page
+        ensureBaseline,
+        onStudiedProgress,
 
-    if (pendingAction === 'half') {
-      setFirstHalfStatus('quizzed');      // continue session
-    } else if (pendingAction === 'onlySecond') {
-      setSecondHalfStatus('quizzed');     // finished second half → close session
-      closeSession();
-    } else if (pendingAction === 'catchUpAll') {
-      setFirstHalfStatus('quizzed');
-      setSecondHalfStatus('quizzed');     // both done → close session
-      closeSession();
-    } else if (pendingAction === 'backlog') {
-      clearBacklog();                      // quiz backlog done → clear
-    }
-
-    const chunk = pendingChunk;
-    setPendingAction(null);
-    setPendingChunk(null);
-    router.push(`/quiz/local?topicId=${topicId}&chunk=${chunk}`);
-  }, [sseStatus, sseData, pendingChunk, pendingAction, topicId, router]);
-
-  return {
-    // UI state
-    promptOpen,
-    promptVariant,
-    percentLabel,
-    isGenerating,
-    showCatchUp,
-
-    // HALF
-    confirmHalfQuiz,
-    skipHalfQuiz,
-
-    // FULL
-    getFullRanges,
-    startFullOnlySecond,
-    startFullCatchUpAll,
-    skipFullQuiz,
-
-    // Backlog
-    backlogCount,
-    startBacklogQuiz,
-
-    // API for Page
-    ensureBaseline,
-    onStudiedProgress,
-
-    sessionEpoch,
-  };
+        sessionEpoch,
+    };
 }

--- a/src/app/[locale]/flashcards/learning/hooks/useQuizMilestones.ts
+++ b/src/app/[locale]/flashcards/learning/hooks/useQuizMilestones.ts
@@ -316,6 +316,12 @@ export function useQuizMilestones({
         catchUpAll: { start: 0, end: t100 }, // [0, t100)
     });
 
+    const getFullCards = () => {
+  const onlySecond = dedupeById(baselineOrder.slice(t50, t100));
+  const catchUpAll = dedupeById(baselineOrder.slice(0,  t100));
+  return { onlySecond, catchUpAll };
+};
+
     // Only second: backlog first half (if Later), quiz second half
     const startFullOnlySecond = async (cards: QuizCard[]) => {
         if (!cards?.length) {
@@ -445,6 +451,7 @@ export function useQuizMilestones({
         startFullOnlySecond,
         startFullCatchUpAll,
         skipFullQuiz,
+        getFullCards,
 
         // Backlog
         backlogCount,

--- a/src/app/[locale]/flashcards/learning/hooks/useQuizMilestones.ts
+++ b/src/app/[locale]/flashcards/learning/hooks/useQuizMilestones.ts
@@ -1,0 +1,417 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { handleConvertToQuestionsEdited } from '@/app/[locale]/question/utils/handleConvertToQuestionsEdited';
+import { IQuestionsFromSSERaw } from '@/app/[locale]/generate/types';
+import { writeLocalQuiz } from '@/app/[locale]/quiz/utils/localQuiz.storage';
+import { buildPayloadFromLearnedFlashcards } from '@/app/[locale]/question/utils/buildGenPayload';
+
+export type QuizCard = {
+  flashcardId: number | string;
+  front: string;
+  back: string;
+  imageUrl?: string | null;
+  topicName?: string | null;
+};
+
+type HalfStatus = 'pending' | 'quizzed' | 'deferred';
+type PromptVariant = 'half' | 'full';
+type PendingAction = 'half' | 'onlySecond' | 'catchUpAll' | 'backlog' | null;
+
+type UseQuizMilestonesParams = {
+  topicId: string;
+  regenerate: (payload: any, type: 'quiz') => Promise<void>;
+  sseData: any;
+  sseStatus: string;          
+  loading: boolean;           
+  chunkRatio?: number;     
+};
+
+/* ---------- localStorage helpers ---------- */
+const keyBaseline      = (topicId: string) => `progressive_quiz_baseline_total:${topicId}`;
+const keyLastRemaining = (topicId: string) => `progressive_quiz_last_remaining:${topicId}`;
+const keyHalf          = (topicId: string, which: 'first'|'second') => `progressive_quiz_half_status:${topicId}:${which}`;
+const keyBacklog       = (topicId: string) => `progressive_quiz_backlog:${topicId}`;
+const keyPendingFirst  = (topicId: string) => `progressive_quiz_pending_first:${topicId}`;
+
+const readNum = (key: string, def = 0) => {
+  if (typeof window === 'undefined') return def;
+  const raw = window.localStorage.getItem(key);
+  const n = raw ? parseInt(raw, 10) : def;
+  return Number.isFinite(n) ? n : def;
+};
+const writeNum = (key: string, n: number) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(key, String(n));
+};
+
+const readBaseline = (topicId: string) => readNum(keyBaseline(topicId), 0);
+const writeBaseline = (topicId: string, n: number) => writeNum(keyBaseline(topicId), n);
+
+const readLastRemaining = (topicId: string) => readNum(keyLastRemaining(topicId), 0);
+const writeLastRemaining = (topicId: string, n: number) => writeNum(keyLastRemaining(topicId), n);
+
+const loadStatus = (topicId: string, which: 'first'|'second'): HalfStatus => {
+  if (typeof window === 'undefined') return 'pending';
+  const raw = window.localStorage.getItem(keyHalf(topicId, which));
+  return (raw as HalfStatus) || 'pending';
+};
+const saveStatus = (topicId: string, which: 'first'|'second', val: HalfStatus) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(keyHalf(topicId, which), val);
+};
+
+/* ---------- Backlog & pending-first helpers ---------- */
+const readBacklog = (topicId: string): QuizCard[] => {
+  if (typeof window === 'undefined') return [];
+  const raw = window.localStorage.getItem(keyBacklog(topicId));
+  if (!raw) return [];
+  try { return JSON.parse(raw) as QuizCard[]; } catch { return []; }
+};
+const writeBacklog = (topicId: string, cards: QuizCard[]) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(keyBacklog(topicId), JSON.stringify(cards));
+};
+
+const readPendingFirst = (topicId: string): QuizCard[] => {
+  if (typeof window === 'undefined') return [];
+  const raw = window.localStorage.getItem(keyPendingFirst(topicId));
+  if (!raw) return [];
+  try { return JSON.parse(raw) as QuizCard[]; } catch { return []; }
+};
+const writePendingFirst = (topicId: string, cards: QuizCard[]) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(keyPendingFirst(topicId), JSON.stringify(cards));
+};
+const clearPendingFirst = (topicId: string) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(keyPendingFirst(topicId));
+};
+
+const dedupeById = (arr: QuizCard[]) => {
+  const seen = new Set<string>();
+  return arr.filter(c => {
+    const id = String(c.flashcardId);
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+};
+
+/* ---------- Standardize QuizCard -> builder type needed ---------- */
+type DueCardLike = {
+  flashcardId: number;
+  front: string;
+  back: string;
+  imageUrl?: string | null;
+  topicName?: string | null;
+};
+
+const normalizeToDue = (c: QuizCard): DueCardLike => ({
+  flashcardId: typeof c.flashcardId === 'string' ? Number(c.flashcardId) : c.flashcardId,
+  front: c.front,
+  back: c.back,
+  imageUrl: c.imageUrl ?? null,
+  topicName: c.topicName ?? null,
+});
+
+/** Always use this helper instead of calling the builder directly to avoid type errors */
+const buildPayloadFromQuizCards = (topicId: string, cards: QuizCard[]) => {
+  const normalized = cards.map(normalizeToDue);
+  return buildPayloadFromLearnedFlashcards(topicId, normalized as any);
+};
+
+export function useQuizMilestones({
+  topicId,
+  regenerate,
+  sseData,
+  sseStatus,
+  loading,
+  chunkRatio = 0.5,
+}: UseQuizMilestonesParams) {
+  const router = useRouter();
+  const [sessionEpoch, setSessionEpoch] = useState<number>(0);
+
+  // Baseline (persisted): “fixed” total of the session
+  const [baselineTotal, setBaselineTotal] = useState<number>(() => readBaseline(topicId));
+  const [lastRemaining, setLastRemaining] = useState<number>(() => readLastRemaining(topicId));
+
+  // Persisted state
+  const [firstHalfStatus, setFirstHalfStatus]   = useState<HalfStatus>(() => loadStatus(topicId, 'first'));
+  const [secondHalfStatus, setSecondHalfStatus] = useState<HalfStatus>(() => loadStatus(topicId, 'second'));
+
+  // Backlog (persisted)
+  const [backlogCount, setBacklogCount] = useState<number>(() => readBacklog(topicId).length);
+
+  useEffect(() => { writeBaseline(topicId, baselineTotal); }, [topicId, baselineTotal]);
+  useEffect(() => { writeLastRemaining(topicId, lastRemaining); }, [topicId, lastRemaining]);
+  useEffect(() => saveStatus(topicId, 'first',  firstHalfStatus),  [topicId, firstHalfStatus]);
+  useEffect(() => saveStatus(topicId, 'second', secondHalfStatus), [topicId, secondHalfStatus]);
+
+  // UI Prompt
+  const [promptOpen, setPromptOpen] = useState(false);
+  const [promptVariant, setPromptVariant] = useState<PromptVariant>('half');
+
+  // Show Catch-up option at 100% if first half is not quizzed
+  const showCatchUp = useMemo(() => firstHalfStatus !== 'quizzed', [firstHalfStatus]);
+
+  // Queue chunk/cards when user confirm
+  const [queuedChunkCards, setQueuedChunkCards] = useState<QuizCard[] | null>(null);
+  const [queuedChunkNumber, setQueuedChunkNumber] = useState<number | null>(null); // 1: 50%, 2: 100%
+
+  // Monitor the generating action to update the state correctly when SSE is finished
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [pendingChunk, setPendingChunk] = useState<number | null>(null);
+
+  // Milestones theo baseline
+  const [t50, t100] = useMemo(() => {
+    if (baselineTotal <= 0) return [0, 0] as const;
+    const half = Math.ceil(baselineTotal * chunkRatio);
+    return [half, baselineTotal] as const;
+  }, [baselineTotal, chunkRatio]);
+
+  const percentLabel = promptVariant === 'half' ? Math.round(chunkRatio * 100) : 100;
+  const isGenerating = pendingChunk !== null && (loading || sseStatus === 'open');
+
+  /* ---------- session helpers ---------- */
+  const closeSession = () => {
+    setBaselineTotal(0);
+    setFirstHalfStatus('pending');
+    setSecondHalfStatus('pending');
+    setPromptOpen(false);
+    setQueuedChunkCards(null);
+    setQueuedChunkNumber(null);
+    setLastRemaining(0);
+    setSessionEpoch((x) => x + 1); // increase epoch at session close
+  };
+
+  /* ---------- Backlog API ---------- */
+  const appendToBacklog = (cards: QuizCard[]) => {
+    if (!cards?.length) return;
+    const cur = readBacklog(topicId);
+    const next = dedupeById([...cards, ...cur]); // newest first
+    writeBacklog(topicId, next);
+    setBacklogCount(next.length);
+  };
+  const clearBacklog = () => {
+    writeBacklog(topicId, []);
+    setBacklogCount(0);
+  };
+  const startBacklogQuiz = async () => {
+    if (isGenerating) return;
+    const cards = readBacklog(topicId);
+    if (cards.length === 0) return;
+    const payload = buildPayloadFromQuizCards(topicId, cards);
+    setPendingChunk(3);                // 3 = type "backlog"
+    setPendingAction('backlog');
+    setPromptOpen(false);
+    await regenerate(payload, 'quiz');
+  };
+
+  /* ---------- API for Page: fix/reset baseline ---------- */
+  const ensureBaseline = (currentRemainingCount: number) => {
+    if (currentRemainingCount < 0) return;
+
+    setLastRemaining(currentRemainingCount); // monitor for increases
+
+    if (currentRemainingCount === 0) return;
+
+    if (baselineTotal === 0) {
+      setBaselineTotal(currentRemainingCount);
+      setFirstHalfStatus('pending');
+      setSecondHalfStatus('pending');
+      setSessionEpoch((x) => x + 1); // open a new session
+      return;
+    }
+
+    if (currentRemainingCount > baselineTotal || currentRemainingCount > lastRemaining) {
+      // Start new session: if old session kept pending-first then move to backlog
+      const pf = readPendingFirst(topicId);
+      if (pf.length) {
+        appendToBacklog(pf);
+        clearPendingFirst(topicId);
+      }
+      setBaselineTotal(currentRemainingCount);
+      setFirstHalfStatus('pending');
+      setSecondHalfStatus('pending');
+      setPromptOpen(false);
+      setQueuedChunkCards(null);
+      setQueuedChunkNumber(null);
+      setSessionEpoch((x) => x + 1); // open a new session
+    }
+  };
+
+  /* ---------- API for Page: progress after each review ---------- */
+  const onStudiedProgress = (
+    studied: QuizCard[],
+    currentRemainingCount: number
+  ) => {
+    if (!baselineTotal || isGenerating || promptOpen) return;
+
+    setLastRemaining(currentRemainingCount);
+
+    const studiedSoFar = baselineTotal - currentRemainingCount;
+
+    // 50% if first half is pending
+    if (t50 > 0 && studiedSoFar >= t50 && firstHalfStatus === 'pending') {
+      const firstSlice = studied.length >= t50 ? studied.slice(0, t50) : studied.slice(); // safety
+      setQueuedChunkCards(firstSlice);
+      setQueuedChunkNumber(1);
+      setPromptVariant('half');
+      setPromptOpen(true);
+      return;
+    }
+
+    // 100% if the second half is pending
+    if (t100 > 0 && studiedSoFar >= t100 && secondHalfStatus === 'pending') {
+      setQueuedChunkCards(null); // full: let Page slice
+      setQueuedChunkNumber(2);
+      setPromptVariant('full');
+      setPromptOpen(true);
+    }
+  };
+
+  /* ---------- 50% actions ---------- */
+  const confirmHalfQuiz = async () => {
+    if (queuedChunkNumber !== 1 || !queuedChunkCards?.length) {
+      setPromptOpen(false);
+      return;
+    }
+    const payload = buildPayloadFromQuizCards(topicId, queuedChunkCards);
+    setPendingChunk(1);
+    setPendingAction('half');
+    setPromptOpen(false);
+    setQueuedChunkCards(null);
+    setQueuedChunkNumber(null);
+    await regenerate(payload, 'quiz');
+  };
+
+  const skipHalfQuiz = () => {
+    // DO NOT push into backlog now — keep pending-first to decide at 100%
+    if (queuedChunkNumber === 1 && queuedChunkCards?.length) {
+      writePendingFirst(topicId, queuedChunkCards);
+    }
+    setFirstHalfStatus('deferred');
+    setPromptOpen(false);
+    setQueuedChunkCards(null);
+    setQueuedChunkNumber(null);
+  };
+
+  /* ---------- 100% actions ---------- */
+  const getFullRanges = () => ({
+    onlySecond: { start: Math.max(0, t50), end: t100 }, // [t50, t100)
+    catchUpAll: { start: 0, end: t100 },                // [0, t100)
+  });
+
+  // Only second: backlog first half (if Later), quiz second half
+  const startFullOnlySecond = async (cards: QuizCard[]) => {
+    if (!cards?.length) { setPromptOpen(false); return; }
+
+    if (firstHalfStatus === 'deferred') {
+      const pf = readPendingFirst(topicId);
+      if (pf.length) appendToBacklog(pf);
+      clearPendingFirst(topicId);
+    }
+
+    const payload = buildPayloadFromQuizCards(topicId, cards);
+    setPendingChunk(2);
+    setPendingAction('onlySecond');
+    setPromptOpen(false);
+    await regenerate(payload, 'quiz');
+  };
+
+  // Catch-up all: quiz both halves, clear pending-first
+  const startFullCatchUpAll = async (cards: QuizCard[]) => {
+    if (!cards?.length) { setPromptOpen(false); return; }
+    clearPendingFirst(topicId);
+    const payload = buildPayloadFromQuizCards(topicId, cards);
+    setPendingChunk(2);
+    setPendingAction('catchUpAll');
+    setPromptOpen(false);
+    await regenerate(payload, 'quiz');
+  };
+
+  // Later at 100%: backlog second half + (if any) first half pending, then close session
+  const skipFullQuiz = (secondHalfCards: QuizCard[]) => {
+    if (secondHalfCards?.length) appendToBacklog(secondHalfCards);
+
+    if (firstHalfStatus === 'deferred') {
+      const pf = readPendingFirst(topicId);
+      if (pf.length) appendToBacklog(pf);
+      clearPendingFirst(topicId);
+    }
+
+    setSecondHalfStatus('deferred');
+    setPromptOpen(false);
+    setQueuedChunkCards(null);
+    setQueuedChunkNumber(null);
+    closeSession();
+  };
+
+  /* ---------- SSE complete ---------- */
+  useEffect(() => {
+    if (pendingChunk === null) return;
+
+    const raw = (sseData as any)?.data?.data as IQuestionsFromSSERaw | undefined;
+    const payloadStatus = (sseData as any)?.data?.status ?? (sseData as any)?.status;
+    const done = sseStatus === 'completed' || payloadStatus === 'completed';
+    if (!done) return;
+    if (!Array.isArray(raw) || raw.length === 0) return;
+
+    const parsed = handleConvertToQuestionsEdited({ type: 'generative', questionsProp: raw });
+    const toStore = parsed.map(q => ({
+      questionText: q.questionText,
+      choices: q.choices,
+      correctIndex: q.correctIndex,
+    }));
+    writeLocalQuiz(topicId, toStore);
+
+    if (pendingAction === 'half') {
+      setFirstHalfStatus('quizzed');      // continue session
+    } else if (pendingAction === 'onlySecond') {
+      setSecondHalfStatus('quizzed');     // finished second half → close session
+      closeSession();
+    } else if (pendingAction === 'catchUpAll') {
+      setFirstHalfStatus('quizzed');
+      setSecondHalfStatus('quizzed');     // both done → close session
+      closeSession();
+    } else if (pendingAction === 'backlog') {
+      clearBacklog();                      // quiz backlog done → clear
+    }
+
+    const chunk = pendingChunk;
+    setPendingAction(null);
+    setPendingChunk(null);
+    router.push(`/quiz/local?topicId=${topicId}&chunk=${chunk}`);
+  }, [sseStatus, sseData, pendingChunk, pendingAction, topicId, router]);
+
+  return {
+    // UI state
+    promptOpen,
+    promptVariant,
+    percentLabel,
+    isGenerating,
+    showCatchUp,
+
+    // HALF
+    confirmHalfQuiz,
+    skipHalfQuiz,
+
+    // FULL
+    getFullRanges,
+    startFullOnlySecond,
+    startFullCatchUpAll,
+    skipFullQuiz,
+
+    // Backlog
+    backlogCount,
+    startBacklogQuiz,
+
+    // API for Page
+    ensureBaseline,
+    onStudiedProgress,
+
+    sessionEpoch,
+  };
+}

--- a/src/app/[locale]/quiz/components/QuizQuestion.tsx
+++ b/src/app/[locale]/quiz/components/QuizQuestion.tsx
@@ -3,43 +3,58 @@
 import { useState } from 'react';
 
 interface QuizQuestionProps {
-    questionNumber: number;
-    questionText: string;
-    choices: string[];
-    onAnswerSelect: (selectedIndex: number) => void;
+  questionNumber: number;
+  questionText: string;
+  choices: string[];
+  onAnswerSelect: (selectedIndex: number) => void;
 }
 
-const QuizQuestion = ({ questionNumber, questionText, choices, onAnswerSelect }: QuizQuestionProps) => {
-    const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
+const QuizQuestion = ({
+  questionNumber,
+  questionText,
+  choices,
+  onAnswerSelect,
+}: QuizQuestionProps) => {
+  const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
 
-    const handleAnswerSelect = (index: number) => {
-        setSelectedAnswer(index);
-        onAnswerSelect(index);
-    };
+  const handleAnswerSelect = (index: number) => {
+    setSelectedAnswer(index);
+    onAnswerSelect(index);
+  };
 
-    return (
-        <div className="bg-background p-6 rounded-lg shadow-lg w-full max-w-3xl mx-auto mb-6 border border-border">
-            <h3 className="text-xl font-semibold text-foreground mb-4">
-                Question {questionNumber}: {questionText}
-            </h3>
+  return (
+    <div className="bg-background p-6 rounded-lg shadow-lg w-full max-w-3xl mx-auto mb-6 border border-border">
+      <h3 className="text-xl font-semibold text-foreground mb-4">
+        Question {questionNumber}: {questionText}
+      </h3>
 
-            {choices
-                .map((choice, index) => ({ choice, index }))
-                .filter(({ choice }) => choice !== null && choice.trim() !== '')
-                .map(({ choice, index }) => (
-                    <div key={index} className="flex items-center space-x-4 mb-4">
-                        <input
-                            type="radio"
-                            name={`question-${questionText}`}
-                            checked={selectedAnswer === index}
-                            onChange={() => handleAnswerSelect(index)}
-                            className="form-radio text-primary h-5 w-5"
-                        />
-                        <label className="text-lg text-muted-foreground">{choice}</label>
-                    </div>
-                ))}
-        </div>
-    );
+      {choices
+        .map((choice, index) => ({ choice, index }))
+        .filter(({ choice }) => choice != null && choice.trim() !== '')
+        .map(({ choice, index }) => {
+          const id = `q${questionNumber}-c${index}`;
+          const isSelected = selectedAnswer === index;
+          return (
+            <label
+              key={id}
+              htmlFor={id}
+              className={`flex items-center gap-3 mb-3 p-3 rounded-md border cursor-pointer transition
+                ${isSelected ? 'border-primary bg-muted' : 'border-border hover:bg-muted'}`}
+            >
+              <input
+                id={id}
+                type="radio"
+                name={`question-${questionNumber}`}
+                checked={isSelected}
+                onChange={() => handleAnswerSelect(index)}
+                className="form-radio text-primary h-5 w-5"
+              />
+              <span className="text-lg text-foreground">{choice}</span>
+            </label>
+          );
+        })}
+    </div>
+  );
 };
 
 export default QuizQuestion;

--- a/src/app/[locale]/quiz/components/QuizQuestion.tsx
+++ b/src/app/[locale]/quiz/components/QuizQuestion.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 interface QuizQuestionProps {
   questionNumber: number;
@@ -16,6 +16,10 @@ const QuizQuestion = ({
   onAnswerSelect,
 }: QuizQuestionProps) => {
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
+  
+  useEffect(() => {
+     setSelectedAnswer(null);
+  }, [questionNumber]);
 
   const handleAnswerSelect = (index: number) => {
     setSelectedAnswer(index);


### PR DESCRIPTION
Quick Quiz at 50% / 100% — How it works
- Study session concept

When you start learning, we lock a baseline = number of due cards at the start.

If the due count increases (new cards arrive), we start a new session. Cards from different sessions don’t mix.

If the previous session still had a deferred first half, it’s moved to backlog when a new session starts.

- At 50% (first half)

When you reach t50 = ceil(baseline × ratio), a prompt appears:

Quiz now (Take quiz): generate a quiz for the first half and mark it as quizzed.

Later: do not push to backlog yet; just mark the first half as deferred. The final decision happens at 100%.

- At 100% (full session)

When you reach t100 = baseline, choose:

Only the new half: quiz second half (from 50% to 100%). If the first half was deferred earlier, send it to backlog. Close the session.

Catch-up all: quiz both halves (0–100%). Clear any deferred-first state. Close the session.

Later: send the second half to backlog and, if the first half is deferred, send it too. Close the session.

Close session = reset baseline/half states; next time we’ll lock a fresh baseline.

- Backlog (deferred cards)

A small  CTA appears in the corner when backlog > 0:
“You have X deferred cards — Quick quiz.”

Clicking it runs a quiz for all backlog cards, then clears the backlog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Milestone-driven quiz prompts at 50% and 100% completion with interactive choices.
  - QuickQuizPrompt modal and Backlog "Catch up" CTA for deferred cards; backlog-driven quiz start.
  - Per-topic session handling with persisted milestone state and local-generation wiring.

- Bug Fixes
  - Rating options safely show next-review intervals and mark unavailable values.

- Refactor
  - Answers fully clickable with improved selection states and accessibility.
  - Progress and prompt flow simplified to milestone-driven orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->