### PR TITLE
feature(Feynman):  implement Round 2 Feynman

### DIFF
--- a/messages/en/common.json
+++ b/messages/en/common.json
@@ -73,7 +73,8 @@
             "updateError": "Failed to update {name}",
             "deleteError": "Failed to delete {name}",
             "fillNumberError": " Please enter numeric",
-            "fillNumberPositiveError": " Please enter positive number"
+            "fillNumberPositiveError": " Please enter positive number",
+            "featureInComing": "Feature coming soon"
         },
         "labels": {
             "name": "Name",

--- a/messages/en/flashcard.json
+++ b/messages/en/flashcard.json
@@ -30,8 +30,9 @@
             "showAnswer": "Show answer",
             "flashcardsRemaining": "flashcards remaining",
             "greatJob": "Great job! 🎉",
-            "flashcardsCompleted": "You've completed all the flashcards for this topic. There's nothing more to learn right now.",
-            "flashcardsEmpty": "There are no flashcards for this topic! Try creating a flashcard set."
+            "flashcardsCompleted": "You've completed all the flashcards for this topic. Now you can assess your knowledge.",
+            "flashcardsEmpty": "There are no flashcards for this topic! Try creating a flashcard set.",
+            "reviewKnowledge": "Review your knowledge."
         },
         "import": {
             "title": "Import your data",

--- a/messages/vi/common.json
+++ b/messages/vi/common.json
@@ -74,7 +74,8 @@
             "updateError": "Không thể cập nhật {name}",
             "deleteError": "Không thể xóa {name}",
             "fillNumberError": "Chỉ nhập số",
-            "fillNumberPositiveError": "Vui lòng nhập số dương"
+            "fillNumberPositiveError": "Vui lòng nhập số dương",
+            "featureInComing": "Tính năng đang phát triển!"
         },
         "labels": {
             "name": "Tên",

--- a/messages/vi/flashcard.json
+++ b/messages/vi/flashcard.json
@@ -30,8 +30,9 @@
             "showAnswer": "Hiện kết quả",
             "flashcardsRemaining": "flashcards còn lại",
             "greatJob": "Làm tốt lắm! 🎉",
-            "flashcardsCompleted": "Bạn đã hoàn thành tất cả flashcard cho chủ đề này. Hiện tại không còn gì để học thêm.",
-            "flashcardsEmpty": "Không có flashcard nào cho topic này! Bạn hãy thử tạo bộ flashcard"
+            "flashcardsCompleted": "Bạn đã hoàn thành tất cả flashcard cho chủ đề này. Hiện tại bạn có thể đánh giá kiến thức của mình.",
+            "flashcardsEmpty": "Không có flashcard nào cho topic này! Bạn hãy thử tạo bộ flashcard",
+            "reviewKnowledge": "Đánh giá kiến thức"
         },
         "import": {
             "title": "Nhập dữ liệu của bạn",

--- a/src/app/[locale]/feynman/[topicId]/page.tsx
+++ b/src/app/[locale]/feynman/[topicId]/page.tsx
@@ -13,10 +13,12 @@ import { FeynmanEditor } from '@/components/feynman/FeynmanEditor';
 import { HintPanel } from '@/components/feynman/HintPanel';
 import { ActionBar } from '@/components/feynman/ActionBar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { isNilOrEmpty, truncate } from '@/utils';
+import { isNilOrEmpty, isNullOrEmpty, truncate } from '@/utils';
 import { FeynmanReviewDialog } from '@/components/feynman/ReviewedDialog';
 import { FeynmanAIResponse, IFeynmanResponseQuestion, IFeynmanReviewedResponse } from '@/components/feynman/types';
 import { TYPE_GENERATE, maxLengthExplain, minWordLength } from '@/components/feynman/config';
+import { toast } from '@/hooks/use-toast';
+import { useTranslations } from 'next-intl';
 
 type PageProps = {
     params: { locale: string };
@@ -28,6 +30,8 @@ export default function FeynmanPage(_props: PageProps) {
     const params = useParams();
     const topicId = params?.topicId as string;
     const method = searchParams?.get('method');
+
+    const tCommon = useTranslations('common');
 
     const [text, setText] = useState<string>('');
     const [highlightedWords, setHighlightedWords] = useState<string[]>([]);
@@ -170,7 +174,11 @@ export default function FeynmanPage(_props: PageProps) {
         }
     }, [isRegisterReview, dataFeynmanReviewed]);
 
-    const handleSave = () => {};
+    const handleSave = () => {
+        toast({
+            description: tCommon('messages.featureInComing'),
+        });
+    };
 
     const handleReset = () => {
         setText('');
@@ -275,6 +283,9 @@ export default function FeynmanPage(_props: PageProps) {
                     isLoadingFetchQuestion={isGeneratingQuestion}
                     isReview={isGeneratingReview}
                     isDisableGetQuestion={isGeneratingQuestion || isGeneratingReview || !!dataFeynmanQuestion}
+                    isDisableSubmit={
+                        !dataFeynmanQuestion || isGeneratingQuestion || isGeneratingReview || isNullOrEmpty(text)
+                    }
                 />
 
                 <FeynmanReviewDialog

--- a/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
+++ b/src/app/[locale]/flashcards/learning/[topicId]/page.tsx
@@ -32,6 +32,8 @@ import { CONTENT_TYPE_GENERATE, IQuestionsFromSSERaw } from '@/app/[locale]/gene
 import { writeLocalQuiz } from '@/app/[locale]/quiz/utils/localQuiz.storage';
 import { buildPayloadFromLearnedFlashcards } from '@/app/[locale]/question/utils/buildGenPayload';
 import { isAfter } from 'date-fns';
+import { ROUTES } from '@/utils/constants/routes';
+import { METHOD_LEARNING } from '@/utils/constants/method';
 
 export type IFlashcardWithReviewPrediction = Pick<
     IFlashcard,
@@ -342,6 +344,10 @@ export default function Page() {
         router.back();
     }
 
+    function handleRedirectFeynmanPage() {
+        router.push(ROUTES.FEYNMAN_REVIEW(topicId, METHOD_LEARNING.FLASHCARD));
+    }
+
     if (flashcardsError) {
         return <div>Error: {flashcardsError}</div>;
     }
@@ -369,9 +375,16 @@ export default function Page() {
                     <div className="pt-4">
                         <Button
                             onClick={handleBackClick}
-                            className="px-6 py-2 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors border border-gray-300"
+                            className="px-6 py-2 mx-10 rounded-lg transition-colors border border-gray-300"
                         >
-                            Go Back
+                            {tCommon('actions.back')}
+                        </Button>
+
+                        <Button
+                            onClick={handleRedirectFeynmanPage}
+                            className="px-6 py-2  rounded-lg transition-colors border border-gray-300"
+                        >
+                            {tFlashcardLearning('reviewKnowledge')}
                         </Button>
                     </div>
                 </div>

--- a/src/components/feynman/ActionBar.tsx
+++ b/src/components/feynman/ActionBar.tsx
@@ -14,6 +14,7 @@ type Props = {
     isLoadingFetchQuestion?: boolean;
     isReview: boolean;
     isDisableGetQuestion: boolean;
+    isDisableSubmit: boolean;
 };
 
 export function ActionBar({
@@ -25,6 +26,7 @@ export function ActionBar({
     clarityScore = 0,
     jargonCount = 0,
     isDisableGetQuestion,
+    isDisableSubmit,
     isLoadingFetchQuestion,
     isReview,
 }: Props) {
@@ -61,7 +63,7 @@ export function ActionBar({
                 <Button onClick={onGetHints} disabled={isDisableGetQuestion}>
                     {isLoadingFetchQuestion ? 'Thinking…' : 'Get Questions & Hints'}
                 </Button>
-                <Button onClick={onSubmit} disabled={isReview}>
+                <Button onClick={onSubmit} disabled={isDisableSubmit}>
                     {isReview ? 'Review…' : 'Submit'}
                 </Button>
             </div>

--- a/src/utils/constants/method.ts
+++ b/src/utils/constants/method.ts
@@ -1,0 +1,6 @@
+export const METHOD_LEARNING = {
+    FLASHCARD: 'flashcard',
+    QUIZ: 'quiz',
+    FEYNMAN: 'feynman',
+    GAMIFICATION: 'gamification',
+};

--- a/src/utils/constants/routes.ts
+++ b/src/utils/constants/routes.ts
@@ -24,6 +24,7 @@ export const ROUTES = Object.freeze({
     PROFILE_PRIVACY: '/setting/profile/privacy',
     PROFILE_SETTINGS: '/setting/profile/settings',
     PAYMENT: (planId: string | number) => `/payment?planId=${planId}`,
+    FEYNMAN_REVIEW: (topicId: string | number, method: string) => `/feynman/${topicId}?method=${method}`,
 
     // ======================= ADMIN ROUTES ========================
 


### PR DESCRIPTION
+ add button redirect after user complete learning for flashcard learning page
+ fix for submit button correct way: only submit when user typing explain and only display  when contains material
+ TODO for save each explanation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Review knowledge” action from Flashcards to the Feynman review page.
  - Displays a toast message indicating “Feature coming soon” where applicable.

- Enhancements
  - Improved submit-button disabling in Feynman to prevent empty or invalid submissions.
  - Refined the “no more flashcards” view with clearer navigation.

- Localization
  - Added “Feature coming soon” and “Review knowledge” translations in English and Vietnamese.
  - Updated the flashcards completion message to suggest assessing knowledge (EN/VI).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->