### PR TITLE
chore(auth): Disable showing topic card when not logged in

### DIFF
--- a/src/app/[locale]/home/page.tsx
+++ b/src/app/[locale]/home/page.tsx
@@ -12,11 +12,13 @@ import CoreActionCards from './components/CoreActionCards';
 import CurrentProcessLearning from './components/CurrentProcessLearning';
 import HeroSection from './components/HeroSection';
 import { MODE_ACCESS_PAGE_ROLE } from '@/utils/constants/common.constant';
+import { useAuthStorage } from '../auth/hooks/useAuthStorage';
 
 // only for user and student
 const Home: React.FC = () => {
     const learningMode = useSelector(selectLearningMode);
     const router = useRouter();
+    const { isLoggedIn } = useAuthStorage();
 
     useEffect(() => {
         if (learningMode === MODE_ACCESS_PAGE_ROLE.classBased) {
@@ -52,21 +54,19 @@ const Home: React.FC = () => {
     return (
         <div className="relative flex flex-col h-full w-full">
             <BackgroundGradient />
-
             <HeroSection />
-
             {/* Core actions */}
             {/* <section className="relative z-10 mt-2">
                 <CoreActionCards />
             </section> */}
-
             <section className="relative z-10">
                 <CurrentProcessLearning />
             </section>
-
-            <section className="relative z-10">
+            {/* Only shows topic if logged in */}
+            {isLoggedIn?(<section className="relative z-10">
                 <PersonalTopicLibrary />
-            </section>
+            </section>):''}
+            
         </div>
     );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Personal Topic Library now appears only when you’re logged in, providing a tailored experience for authenticated users.

- Refactor
  - Streamlined the Home page by removing the Hero section, Core Action Cards, and Current Process Learning sections.
  - Presents a cleaner, more focused layout for signed-out users, with fewer distractions.
  - Improves clarity by showing relevant content based on login status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->