### PR TITLE
fix(auth): show toast message if already registered with password login

### DIFF
--- a/src/app/[locale]/auth/hooks/useGoogleAuth.ts
+++ b/src/app/[locale]/auth/hooks/useGoogleAuth.ts
@@ -6,6 +6,7 @@ import { useAuthNavigation } from '@/hooks/useAuthNavigation';
 import { useAuth } from '@/contexts/auth/AuthContext';
 import { User } from '@/types/auth';
 import { createGoogleAuthUrl } from '../login/utils/googleAuth';
+import toastHelper from '@/utils/toast.helper';
 
 export const useGoogleAuth = () => {
     const [isLoading, setIsLoading] = useState(false);
@@ -44,6 +45,7 @@ export const useGoogleAuth = () => {
                 handleSuccessfulLogin(userData);
             } catch (error) {
                 console.error('Google auth error:', error);
+                toastHelper.showErrorMessage(error);
             } finally {
                 setIsLoading(false);
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Show a clear error message when Google sign-in fails, improving user feedback without changing loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->