### PR TITLE
feat(schedule): apply multiple language for setting preference schedule page

### DIFF
--- a/messages/en/schedule.json
+++ b/messages/en/schedule.json
@@ -32,6 +32,25 @@
             "save": "Save changes",
             "cancel": "Cancel",
             "errorSaveMessage": "There was an error saving your changes. Please try again."
+        },
+        "setup": {
+            "pageTitle": "Schedule Setup",
+            "freeTime": {
+                "title": "Free time during the week",
+                "description": "Choose a time period you can study each day"
+            },
+            "studyHabits": {
+                "title": "Study habits",
+                "description": "The system will suggest a schedule that suits you better."
+            },
+            "actions": {
+                "save": "Save",
+                "saving": "Saving..."
+            },
+            "messages": {
+                "saveError": "Unable to save settings. Please try again later.",
+                "errorOccurred": "An error occurred: {error}"
+            }
         }
     }
 }

--- a/messages/vi/schedule.json
+++ b/messages/vi/schedule.json
@@ -32,6 +32,25 @@
             "save": "Lưu thay đổi",
             "cancel": "Hủy",
             "errorSaveMessage": "Có lỗi xảy ra khi lưu thay đổi. Vui lòng thử lại."
+        },
+        "setup": {
+            "pageTitle": "Thiết lập lịch học",
+            "freeTime": {
+                "title": "Thời gian rảnh trong tuần",
+                "description": "Chọn khung giờ bạn có thể học mỗi ngày"
+            },
+            "studyHabits": {
+                "title": "Thói quen học",
+                "description": "Hệ thống sẽ gợi ý lịch học phù hợp với bạn hơn."
+            },
+            "actions": {
+                "save": "Lưu",
+                "saving": "Đang lưu..."
+            },
+            "messages": {
+                "saveError": "Không thể lưu cài đặt. Vui lòng thử lại sau.",
+                "errorOccurred": "Đã xảy ra lỗi: {error}"
+            }
         }
     }
 }

--- a/src/app/[locale]/setting/schedule-setup/components/SetupForm.tsx
+++ b/src/app/[locale]/setting/schedule-setup/components/SetupForm.tsx
@@ -8,12 +8,14 @@ import { toast } from '@/hooks/use-toast';
 import { useGetSchedulePreferences, useUpdateSchedulePreferences } from '@/hooks/useSchedule';
 import { IFreeTime, IUpdateSchedulePreferencePayload } from '@/services/schedule/schedule.types';
 import React, { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 
 type Props = {
     onComplete: () => void;
 };
 
 export default function SetupForm({ onComplete }: Props) {
+    const t = useTranslations('schedule.setup');
     const [formData, setFormData] = useState<IUpdateSchedulePreferencePayload>({
         preferences: {
             studyMethods: [],
@@ -51,7 +53,7 @@ export default function SetupForm({ onComplete }: Props) {
             }
         } catch (error) {
             toast({
-                description: 'Unable to save settings. Please try again later.',
+                description: t('messages.saveError'),
                 variant: 'destructive',
             });
         }
@@ -64,14 +66,14 @@ export default function SetupForm({ onComplete }: Props) {
     return (
         <div className="space-y-8 p-6 bg-white rounded shadow">
             <section>
-                <h2 className="text-xl font-semibold mb-2">Free time during the week</h2>
-                <p className="text-sm text-gray-500 mb-4">Choose a time period you can study each day</p>
+                <h2 className="text-xl font-semibold mb-2">{t('freeTime.title')}</h2>
+                <p className="text-sm text-gray-500 mb-4">{t('freeTime.description')}</p>
                 <FreeTimeSelector initialData={formData?.freeTime} onChange={handleFreeTimeChange} />
             </section>
 
             <section>
-                <h2 className="text-xl font-semibold mb-2">Study habits</h2>
-                <p className="text-sm text-gray-500 mb-4">The system will suggest a schedule that suits you better.</p>
+                <h2 className="text-xl font-semibold mb-2">{t('studyHabits.title')}</h2>
+                <p className="text-sm text-gray-500 mb-4">{t('studyHabits.description')}</p>
                 <StudyPreference initialData={formData} onChange={setFormData} />
             </section>
 
@@ -81,13 +83,13 @@ export default function SetupForm({ onComplete }: Props) {
                     onClick={handleSubmit}
                     className="bg-primary text-white hover:bg-primary-dark transition-colors"
                 >
-                    <span className="text-sm font-medium">{updating ? 'Saving...' : 'Save'}</span>
+                    <span className="text-sm font-medium">{updating ? t('actions.saving') : t('actions.save')}</span>
                 </Button>
             </div>
 
             {error && (
                 <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
-                    An error occurred: {error}
+                    {t('messages.errorOccurred', { error })}
                 </div>
             )}
         </div>

--- a/src/app/[locale]/setting/schedule-setup/page.tsx
+++ b/src/app/[locale]/setting/schedule-setup/page.tsx
@@ -2,9 +2,11 @@
 
 import SetupForm from '@/app/[locale]/setting/schedule-setup/components/SetupForm';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
 const ScheduleSetupPage = () => {
     const router = useRouter();
+    const t = useTranslations('schedule.setup');
 
     const handleComplete = () => {
         // You can add success notification here if needed
@@ -14,7 +16,7 @@ const ScheduleSetupPage = () => {
 
     return (
         <div className="max-w-full p-6 bg-white rounded-md shadow-sm overflow-auto">
-            <h1 className="text-xl font-semibold">Schedule Setup</h1>
+            <h1 className="text-xl font-semibold">{t('pageTitle')}</h1>
             <SetupForm onComplete={handleComplete} />
         </div>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a localized Schedule Setup experience with support for English and Vietnamese, including page title, Free Time and Study Habits sections, Save/Saving actions, and consistent error messages.

* Refactor
  * Replaced hard-coded text with translation-based labels and messages across the Schedule Setup page and form to improve internationalization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->