### PR TITLE
fix(feynman): fix issue #359

### DIFF
--- a/messages/en/feynman.json
+++ b/messages/en/feynman.json
@@ -48,6 +48,10 @@
         "closeDialog": "Close",
         "stepLabel": "Step {index}",
         "hideMore": "Hide more",
-        "showMore": "Show {count} more"
+        "showMore": "Show {count} more",
+        "messages": {
+            "emptyOriginContent": "Origin content empty",
+            "flashcard": "flashcard"
+        }
     }
 }

--- a/messages/vi/feynman.json
+++ b/messages/vi/feynman.json
@@ -48,6 +48,10 @@
         "closeDialog": "Đóng",
         "stepLabel": "Bước {index}",
         "hideMore": "Ẩn bớt",
-        "showMore": "Xem thêm"
+        "showMore": "Xem thêm",
+        "messages": {
+            "emptyOriginContent": "Không có nội dung",
+            "flashcard": "flashcard"
+        }
     }
 }

--- a/src/app/[locale]/feynman/[topicId]/page.tsx
+++ b/src/app/[locale]/feynman/[topicId]/page.tsx
@@ -333,14 +333,8 @@ export default function FeynmanPage() {
     }, []);
 
     const isDisableGetQuestionButton = useMemo(() => {
-        return (
-            isGeneratingQuestion ||
-            isGeneratingReview ||
-            !!dataFeynmanQuestion ||
-            !originContent ||
-            isFetchDataOriginMethod
-        );
-    }, [isGeneratingQuestion, isGeneratingReview, dataFeynmanQuestion]);
+        return isGeneratingQuestion || isGeneratingReview || !!dataFeynmanQuestion || !originContent;
+    }, [isGeneratingQuestion, isGeneratingReview, dataFeynmanQuestion, originContent]);
 
     const isDisableSubmitReviewButton = useMemo(() => {
         return !dataFeynmanQuestion || isGeneratingQuestion || isGeneratingReview || isNullOrEmpty(text);

--- a/src/app/[locale]/feynman/[topicId]/page.tsx
+++ b/src/app/[locale]/feynman/[topicId]/page.tsx
@@ -11,16 +11,16 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { FeynmanEditor } from '@/components/feynman/FeynmanEditor';
-import { HintPanel } from '@/components/feynman/HintPanel';
 import { ActionBar } from '@/components/feynman/ActionBar';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { isNilOrEmpty, isNullOrEmpty, toNumber, truncate } from '@/utils';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { isNilOrEmpty, isNullOrEmpty, toNumber } from '@/utils';
 import { FeynmanReviewDialog } from '@/components/feynman/ReviewedDialog';
 import { IFeynmanResponseQuestion, IFeynmanReviewedResponse } from '@/components/feynman/types';
 import { TYPE_GENERATE, maxLengthExplain, minWordLength } from '@/components/feynman/config';
 import { useFeynmanService } from './hooks/useFeynmanService';
 import History from '@/components/feynman/History';
 import LeftMissionPanel from '@/components/feynman/LeftMissionPanel';
+import { toast } from '@/hooks/use-toast';
 
 export default function FeynmanPage() {
     const tCommon = useTranslations('common');
@@ -51,7 +51,19 @@ export default function FeynmanPage() {
         data: originContent,
         loading: isFetchDataOriginMethod,
         error: errorFetchDataOriginMethod,
-    } = useFetch(() => handleGetOriginContent(method!), { shouldRun: isValidToFetchOriginDataMethod() });
+    } = useFetch(() => handleGetOriginContent(method!), {
+        shouldRun: isValidToFetchOriginDataMethod(),
+        onError: () => {
+            toast({
+                description: tCommon('messages.readError', { name: tFeynman('messages.flashcard') }),
+            });
+        },
+        onEmpty: () => {
+            toast({
+                description: tFeynman('messages.emptyOriginContent'),
+            });
+        },
+    });
 
     const {
         execute: executeGetQuestion,
@@ -321,7 +333,13 @@ export default function FeynmanPage() {
     }, []);
 
     const isDisableGetQuestionButton = useMemo(() => {
-        return isGeneratingQuestion || isGeneratingReview || !!dataFeynmanQuestion;
+        return (
+            isGeneratingQuestion ||
+            isGeneratingReview ||
+            !!dataFeynmanQuestion ||
+            !originContent ||
+            isFetchDataOriginMethod
+        );
     }, [isGeneratingQuestion, isGeneratingReview, dataFeynmanQuestion]);
 
     const isDisableSubmitReviewButton = useMemo(() => {

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -3,6 +3,7 @@ import { FetchOptions, METHOD } from './type';
 import { callApiAsync } from './helper';
 import { z } from 'zod';
 import { AxiosError } from 'axios';
+import { isEmpty } from '@/utils';
 
 /**
  * Custom hook for fetching data from an API or via a provided function with Zod validation
@@ -22,6 +23,9 @@ interface Options<Z> {
     selector?: Function;
     schema?: z.ZodType<Z>;
     shouldRun?: boolean | ((...args: any[]) => boolean);
+    onSuccess?: (...args: any[]) => void;
+    onError?: (...args: any[]) => void;
+    onEmpty?: (...args: any[]) => void;
 }
 
 function useFetch<T, Z = T>(
@@ -84,15 +88,23 @@ function useFetch<T, Z = T>(
                 // If no schema provided, cast the data as Z
                 setData(rawData as Z);
             }
+
+            if (isEmpty(rawData)) {
+                options?.onEmpty?.();
+            } else {
+                options?.onSuccess?.(data);
+            }
         } catch (error) {
             if (error instanceof DOMException && error.name === 'AbortError') {
                 return;
             }
-            if(error instanceof AxiosError) {
+            if (error instanceof AxiosError) {
                 setError(error.response?.data.message);
             } else {
                 setError(error instanceof Error ? error.message : 'Unknown error');
             }
+
+            options?.onError?.(error);
         } finally {
             // Check the signal from our local controller variable
             if (!currentController.signal.aborted) {

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -71,11 +71,12 @@ function useFetch<T, Z = T>(
             // apply in here to select customized param
             if (selector && rawData) rawData = selector(rawData);
 
+            let finalData: Z;
+
             // Apply Zod validation if schema is provided
             if (schema) {
                 try {
-                    const validatedData = schema.parse(rawData);
-                    setData(validatedData);
+                    finalData = schema.parse(rawData);
                 } catch (validationError) {
                     if (validationError instanceof z.ZodError) {
                         throw new Error(
@@ -85,11 +86,12 @@ function useFetch<T, Z = T>(
                     throw validationError;
                 }
             } else {
-                // If no schema provided, cast the data as Z
-                setData(rawData as Z);
+                finalData = rawData as Z;
             }
 
-            if (isEmpty(rawData)) {
+            setData(finalData);
+
+            if (isEmpty(finalData as unknown)) {
                 options?.onEmpty?.();
             } else {
                 options?.onSuccess?.(data);

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,3 +1,5 @@
+import { object } from 'zod';
+
 /**
  * Converts various string formats to a number.
  * Supports thousand separators, comma decimals, underscores, currency symbols, and scientific notation.
@@ -51,13 +53,41 @@ const toTitleCase = (str: string): string => {
 };
 
 /**
+ *
+ * @param value
+ * @returns True if list is empty, false otherwise.
+ */
+const isListEmpty = (value: unknown[]): boolean => {
+    return value.length === 0;
+};
+
+/**
+ *
+ * @param obj
+ * @returns True if the object is empty, false otherwise.
+ */
+const isObjectEmpty = (obj: object): boolean => {
+    return Object.keys(obj).length === 0 && obj.constructor === Object;
+};
+
+/**
  * Checks if an object is empty (has no own properties).
  *
  * @param obj - The object to be checked.
- * @returns True if the object is empty, false otherwise.
+ * @returns return empty for unknown type
  */
-const isEmpty = (obj: object): boolean => {
-    return Object.keys(obj).length === 0 && obj.constructor === Object;
+const isEmpty = (value: unknown): boolean => {
+    if (value === null || value === undefined) return true;
+
+    if (typeof value === 'string') return isNullOrEmpty(value);
+
+    if (Array.isArray(value)) return isListEmpty(value);
+
+    if (typeof value === 'object') {
+        return isObjectEmpty(value);
+    }
+
+    return false;
 };
 
 /**


### PR DESCRIPTION
fix issue:
+ https://github.com/perinst/dozu-ui-service/issues/359

Add option onError , onSuccess, onEmpty after get data from server from API for useFetch hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added toast notifications on the Feynman page for load errors and when origin content is empty.
  - Expanded English and Vietnamese translations with messages for empty content and a flashcard label.

- **Bug Fixes**
  - “Get Question” is now disabled when source content is missing or still loading, preventing invalid actions and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->