### PR TITLE
feat(feynman): add auth for page index

### DIFF
--- a/src/app/[locale]/feynman/[topicId]/page.tsx
+++ b/src/app/[locale]/feynman/[topicId]/page.tsx
@@ -21,8 +21,9 @@ import { useFeynmanService } from './hooks/useFeynmanService';
 import History from '@/components/feynman/History';
 import LeftMissionPanel from '@/components/feynman/LeftMissionPanel';
 import { toast } from '@/hooks/use-toast';
+import { withAuth } from '@/hoc/withAuth';
 
-export default function FeynmanPage() {
+const FeynmanPage = () => {
     const tCommon = useTranslations('common');
     const tFeynman = useTranslations('feynman');
 
@@ -439,4 +440,6 @@ export default function FeynmanPage() {
             {renderLeftSide()}
         </div>
     );
-}
+};
+
+export default withAuth(FeynmanPage);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Feynman topic pages are now protected behind sign-in. Unauthenticated users are redirected to log in and returned to their original destination after authentication.
- Refactor
  - Updated page component structure for consistency and maintainability with no visual or functional changes beyond authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->