### PR TITLE
fix(generate): prevent crash when Redux slices are undefined in useContentGeneration (#410)

### DIFF
--- a/src/app/[locale]/generate/hooks/useContentGeneration.ts
+++ b/src/app/[locale]/generate/hooks/useContentGeneration.ts
@@ -66,9 +66,9 @@ export const useContentGeneration = ({
         contentType: contentTypeResourceImport,
         videoInfo,
         transcriptSegments,
-    } = useCardImportSelector((state) => state.contentExtraction);
+    } = useCardImportSelector((state) => state.contentExtraction ?? {} );
 
-    const { importMethod, files: filesImport } = useCardImportSelector((state) => state.importDialog);
+    const { importMethod, files: filesImport } = useCardImportSelector((state) => state.importDialog ?? {} );
 
     const router = useRouter();
     const dispatch = useCardImportDispatch();


### PR DESCRIPTION
#410
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability in content generation by adding protective safeguards to prevent potential errors when accessing state values during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->