### PR TITLE
Fix(upgradePlan): only display button upgrade plan when already login

### DIFF
--- a/src/components/side-bar/SideBar.tsx
+++ b/src/components/side-bar/SideBar.tsx
@@ -77,7 +77,7 @@ const secondaryItems = [
 
 export function AppSidebar() {
     const pathname = usePathname();
-    const { hasRole, currentPlanUser } = useAuth();
+    const { hasRole, currentPlanUser,isAuthenticated } = useAuth();
     const { openUpgradeModal } = useUpgradeModal();
 
     const isPro = currentPlanUser?.plan?.name?.toLowerCase().includes('pro') ?? false;
@@ -182,7 +182,7 @@ export function AppSidebar() {
                         <LanguageSwitcher />
                     </div>
                     {/* Upgrade to Pro Button */}
-                    {!isPro && (
+                    {!isPro && isAuthenticated && (
                         <div className="px-2 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
                             <Button
                                 onClick={openUpgradeModal}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication state handling - "Upgrade to Pro" button now properly respects user authentication status and only displays when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->