### PR TITLE
feat(notifications): setting notification in profile

### DIFF
--- a/src/app/[locale]/profile/components/AccountSettings.tsx
+++ b/src/app/[locale]/profile/components/AccountSettings.tsx
@@ -6,6 +6,8 @@ import { Label } from '@/components/ui/label';
 import { Loader2, Bell } from 'lucide-react';
 import { NotificationSettings, PrivacySettings } from '../../../../types/profile';
 import { ProfileService } from '../../../../services/profile/profileService';
+import toastHelper from '@/utils/toast.helper';
+import { useAuth } from '@/contexts/auth/AuthContext';
 
 interface AccountSettingsProps {
   onSettingsChange?: (notifications: NotificationSettings, privacy: PrivacySettings) => Promise<void>;
@@ -16,6 +18,7 @@ const AccountSettings: React.FC<AccountSettingsProps> = ({
   onSettingsChange, 
   onDeleteAccount 
 }) => {
+  const { refreshNotificationSettings } = useAuth();
   const [notifications, setNotifications] = useState<NotificationSettings>({
     dailyReminders: true,
     weeklyReports: true,
@@ -68,20 +71,17 @@ const AccountSettings: React.FC<AccountSettingsProps> = ({
   const someNotificationsEnabled = Object.values(notifications).some(v => v);
 
   const handleSaveSettings = async () => {
+    setSaveLoading(true);
     try {
-      setSaveLoading(true);
-      
-      if (onSettingsChange) {
-        // Pass empty privacy object since we removed Privacy Settings UI
-        await onSettingsChange(notifications, {} as PrivacySettings);
-        alert('Settings saved successfully!');
-      } else {
-        // Fallback: save directly to backend
-        await ProfileService.updateNotificationSettings(notifications);
-        alert('Settings saved successfully!');
-      }
-    } catch (error: any) {
-      console.error('❌ Failed to save settings:', error);
+      await (onSettingsChange 
+        ? onSettingsChange(notifications, {} as PrivacySettings)
+        : ProfileService.updateNotificationSettings(notifications)
+      );
+      // Refresh notification settings in AuthContext to update WebSocket behavior
+      await refreshNotificationSettings();
+      toastHelper.showSuccessMessage('Settings saved successfully!');
+    } catch (error) {
+      toastHelper.showErrorMessage(error);
     } finally {
       setSaveLoading(false);
     }

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -9,6 +9,8 @@ import { User, UserType } from '@/types/auth';
 import { getUserType } from '@/utils/auth/redirectService';
 import { storeSessionData } from '@/utils/storage';
 import { useWebSocket } from '@/hooks/useWebSocket';
+import { NotificationSettings } from '@/types/profile';
+import { ProfileService } from '@/services/profile/profileService';
 
 interface AuthContextType {
     user: User | null | undefined;
@@ -17,6 +19,7 @@ interface AuthContextType {
     hasCompletedOnboarding: boolean;
     userType: UserType;
     currentPlanUser: ICurrentPlan | null;
+    notificationSettings: NotificationSettings | null;
     setAuthData: (userData: User) => void;
     clearAuthData: () => void;
     hasRole: (role: string) => boolean;
@@ -24,6 +27,7 @@ interface AuthContextType {
     updateUser: (userData: Partial<User>) => void;
     markOnboardingComplete: () => void;
     refreshUserPlan: () => Promise<void>;
+    refreshNotificationSettings: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -35,6 +39,50 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         useAuthStorage();
 
     const [currentPlanUser, setCurrentPlanUser] = useState<ICurrentPlan | null>(null);
+    const [notificationSettings, setNotificationSettings] = useState<NotificationSettings | null>(null);
+
+    // Load notification settings
+    const loadNotificationSettings = useCallback(async () => {
+        if (!isAuthenticated) {
+            setNotificationSettings(null);
+            return;
+        }
+
+        try {
+            const profile = await ProfileService.getProfile();
+            if (profile.notificationSettings) {
+                setNotificationSettings(profile.notificationSettings);
+            } else {
+                // Use default settings if not set
+                setNotificationSettings({
+                    dailyReminders: true,
+                    weeklyReports: true,
+                    achievementNotifications: true,
+                    emailNotifications: true,
+                    pushNotifications: true,
+                });
+            }
+        } catch (error) {
+            console.error('Failed to load notification settings:', error);
+            // Use default settings on error
+            setNotificationSettings({
+                dailyReminders: true,
+                weeklyReports: true,
+                achievementNotifications: true,
+                emailNotifications: true,
+                pushNotifications: true,
+            });
+        }
+    }, [isAuthenticated]);
+
+    // Load settings when authenticated
+    useEffect(() => {
+        if (isAuthenticated) {
+            loadNotificationSettings();
+        } else {
+            setNotificationSettings(null);
+        }
+    }, [isAuthenticated, loadNotificationSettings]);
 
     // Initialize WebSocket connection for notifications
     // Memoize callback to prevent unnecessary reconnections
@@ -46,6 +94,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     useWebSocket({
         enabled: isAuthenticated,
         onNotification: handleNotification,
+        notificationSettings: notificationSettings || undefined,
     });
 
     const checkAuthStatus = useCallback(async () => {
@@ -132,6 +181,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             hasCompletedOnboarding,
             userType,
             currentPlanUser,
+            notificationSettings,
             setAuthData,
             clearAuthData,
             hasRole,
@@ -139,8 +189,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             updateUser,
             markOnboardingComplete,
             refreshUserPlan: getUserCurrentPlan,
+            refreshNotificationSettings: loadNotificationSettings,
         };
-    }, [user, isLoading, hasRole, hasPermission, updateUser, markOnboardingComplete, getUserCurrentPlan, currentPlanUser]);
+    }, [user, isLoading, hasRole, hasPermission, updateUser, markOnboardingComplete, getUserCurrentPlan, currentPlanUser, notificationSettings, loadNotificationSettings]);
 
     return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
 }

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAuthStorage } from '@/app/[locale]/auth/hooks/useAuthStorage';
 import { getAllFeatureBelongPlan, getCurrentPlanSubscription } from '@/services/features/feature.service';
@@ -40,6 +40,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const [currentPlanUser, setCurrentPlanUser] = useState<ICurrentPlan | null>(null);
     const [notificationSettings, setNotificationSettings] = useState<NotificationSettings | null>(null);
+    const isAuthenticatedRef = useRef(isAuthenticated);
+
+    useEffect(() => {
+        isAuthenticatedRef.current = isAuthenticated;
+    }, [isAuthenticated]);
 
     // Load notification settings
     const loadNotificationSettings = useCallback(async () => {
@@ -50,6 +55,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         try {
             const profile = await ProfileService.getProfile();
+            if (!isAuthenticatedRef.current) {
+                return;
+            }
             if (profile.notificationSettings) {
                 setNotificationSettings(profile.notificationSettings);
             } else {
@@ -64,6 +72,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             }
         } catch (error) {
             console.error('Failed to load notification settings:', error);
+            if (!isAuthenticatedRef.current) {
+                return;
+            }
             // Use default settings on error
             setNotificationSettings({
                 dailyReminders: true,
@@ -119,6 +130,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const getUserCurrentPlan = useCallback(async () => {
         const { data } = await getCurrentPlanSubscription();
+
+        if (!isAuthenticatedRef.current) {
+            return;
+        }
 
         const { plan } = data;
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Socket, io } from 'socket.io-client';
 import { useAuthStorage } from '@/app/[locale]/auth/hooks/useAuthStorage';
 import { toast } from '@/hooks/use-toast';
+import { NotificationSettings } from '@/types/profile';
 
 interface NotificationData {
   id: string;
@@ -20,6 +21,7 @@ interface UseWebSocketOptions {
   onNotification?: (data: NotificationData) => void;
   autoReconnect?: boolean;
   reconnectDelay?: number;
+  notificationSettings?: NotificationSettings;
 }
 
 export function useWebSocket(options: UseWebSocketOptions = {}) {
@@ -28,7 +30,44 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     onNotification,
     autoReconnect = true,
     reconnectDelay = 3000,
+    notificationSettings,
   } = options;
+
+  // Default settings if not provided
+  const defaultSettings: NotificationSettings = {
+    dailyReminders: true,
+    weeklyReports: true,
+    achievementNotifications: true,
+    emailNotifications: true,
+    pushNotifications: true,
+  };
+
+  const settings = notificationSettings || defaultSettings;
+  
+  // Use ref to always access latest settings in socket event handlers
+  const settingsRef = useRef(settings);
+  
+  // Update ref when settings change
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
+
+  // Helper function to check if notification should be shown
+  const shouldShowNotification = (type: NotificationData['type']): boolean => {
+    const currentSettings = settingsRef.current;
+    switch (type) {
+      case 'achievement':
+        return currentSettings.achievementNotifications;
+      case 'reminder':
+        return currentSettings.dailyReminders;
+      case 'progress':
+        return currentSettings.weeklyReports;
+      case 'system':
+        return currentSettings.pushNotifications || currentSettings.emailNotifications;
+      default:
+        return true;
+    }
+  };
 
   const { user, isAuthenticated } = useAuthStorage();
   const socketRef = useRef<Socket | null>(null);
@@ -173,14 +212,18 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     socket.on('notification', (data: NotificationData) => {
       console.log('[WebSocket] Received notification:', data);
 
-      // Show toast notification
-      toast({
-        title: data.title,
-        description: data.message,
-        variant: data.type === 'system' ? 'default' : 'default',
-      });
+      // Check if notification should be shown based on user settings
+      if (shouldShowNotification(data.type)) {
+        // Show toast notification
+        toast({
+          title: data.title,
+          description: data.message,
+          variant: data.type === 'system' ? 'default' : 'default',
+        });
+      }
 
-      // Call custom handler if provided (use ref to avoid stale closure)
+      // Always call custom handler if provided (use ref to avoid stale closure)
+      // This allows components to handle notifications even if toast is disabled
       if (onNotificationRef.current) {
         onNotificationRef.current(data);
       }
@@ -199,6 +242,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       currentUserIdRef.current = null;
     };
     // Only depend on values that should trigger reconnection, not callbacks
+    // Note: notificationSettings changes don't require reconnection, only affect toast display
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, isAuthenticated, user?.userId, autoReconnect, reconnectDelay]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can configure which notification types they receive: achievements, reminders, progress updates, and system notifications.

* **Improvements**
  * Notification preferences are now saved and synchronized across the app and immediately applied to live notifications.
  * Saving settings shows clear toast feedback (success/error) and uses an explicit loading state.
  * Notification display now respects user preferences so unwanted toasts are suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->