### PR TITLE
feat(apikey): implement ui to management api key in admin v1

### DIFF
--- a/src/app/[locale]/admin/llm-api-key-models/components/Columns.tsx
+++ b/src/app/[locale]/admin/llm-api-key-models/components/Columns.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import { LlmApiKeyModel } from '@/types/llm-admin/llmApiKeyModel';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Edit, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { getProviderColor } from '@/utils/providerColors';
+import { DeleteApiKeyModelDialog } from './DeleteApiKeyModelDialog';
+
+function ActionButtons({
+    relation,
+    refetch,
+    onEdit,
+}: {
+    relation: LlmApiKeyModel;
+    refetch: () => void;
+    onEdit: (relation: LlmApiKeyModel) => void;
+}) {
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+    const handleDeleteSuccess = () => {
+        refetch();
+    };
+
+    return (
+        <>
+            <div className="flex gap-2">
+                <Button variant="outline" size="sm" onClick={() => onEdit(relation)} title="Edit relation">
+                    <Edit className="h-4 w-4" />
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setDeleteDialogOpen(true)}
+                    title="Delete relation"
+                    className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                >
+                    <Trash2 className="h-4 w-4" />
+                </Button>
+            </div>
+
+            <DeleteApiKeyModelDialog
+                relation={relation}
+                open={deleteDialogOpen}
+                onOpenChange={setDeleteDialogOpen}
+                onSuccess={handleDeleteSuccess}
+            />
+        </>
+    );
+}
+
+export const getLlmApiKeyModelColumns = (
+    refetch: () => void,
+    onEdit: (relation: LlmApiKeyModel) => void
+): ColumnDef<LlmApiKeyModel>[] => [
+    {
+        accessorKey: 'id',
+        header: 'ID',
+        size: 60,
+    },
+    {
+        accessorKey: 'providerName',
+        header: 'Provider',
+        cell: ({ row }) => {
+            const providerName = row.original.providerName || 'Unknown';
+            const colors = getProviderColor(providerName);
+            return (
+                <Badge 
+                    className="text-white border-0"
+                    style={{
+                        background: `linear-gradient(to right, ${colors.gradientFrom}, ${colors.gradientTo})`,
+                    }}
+                >
+                    {providerName}
+                </Badge>
+            );
+        },
+    },
+    {
+        accessorKey: 'modelName',
+        header: 'Model',
+        cell: ({ row }) => (
+            <div className="font-medium">
+                {row.original.modelName || `Model ${row.original.modelId}`}
+            </div>
+        ),
+    },
+    {
+        accessorKey: 'apiKeyId',
+        header: 'API Key ID',
+        cell: ({ row }) => <span className="font-mono text-sm">{row.original.apiKeyId}</span>,
+    },
+    {
+        accessorKey: 'requestPerMinute',
+        header: 'Requests/Min',
+        cell: ({ row }) => (
+            <span className="font-mono">{row.original.requestPerMinute}</span>
+        ),
+    },
+    {
+        accessorKey: 'requestPerDay',
+        header: 'Requests/Day',
+        cell: ({ row }) => (
+            <span className="font-mono">{row.original.requestPerDay}</span>
+        ),
+    },
+    {
+        accessorKey: 'createdAt',
+        header: 'Created At',
+        cell: ({ row }) => {
+            const date = new Date(row.original.createdAt);
+            return <span className="text-sm text-muted-foreground">{date.toLocaleDateString()}</span>;
+        },
+    },
+    {
+        id: 'action',
+        header: 'Actions',
+        cell: ({ row }) => <ActionButtons relation={row.original} refetch={refetch} onEdit={onEdit} />,
+    },
+];
+

--- a/src/app/[locale]/admin/llm-api-key-models/components/CreateEditLlmApiKeyModelDialog.tsx
+++ b/src/app/[locale]/admin/llm-api-key-models/components/CreateEditLlmApiKeyModelDialog.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import usePost from '@/hooks/usePost';
+import { toast } from '@/hooks/use-toast';
+import { CreateLlmApiKeyModelInput, UpdateLlmApiKeyModelInput, LlmApiKeyModel } from '@/types/llm-admin/llmApiKeyModel';
+import { LlmApiKey, LlmApiKeysResponse } from '@/types/llm-admin/llmApiKey';
+import { LlmModel, LlmModelsResponse } from '@/types/llm-admin/llmModel';
+import errorHelper from '@/utils/error.helper';
+import { getRequest } from '@/api/api';
+import { ApiResponse } from '@/api/type';
+import { ROUTES } from '@/utils/constants/routes';
+
+interface CreateEditLlmApiKeyModelDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: () => void;
+    relation?: LlmApiKeyModel | null;
+}
+
+export function CreateEditLlmApiKeyModelDialog({
+    open,
+    onOpenChange,
+    onSuccess,
+    relation,
+}: CreateEditLlmApiKeyModelDialogProps) {
+    const [formData, setFormData] = useState<CreateLlmApiKeyModelInput>({
+        apiKeyId: 0,
+        modelId: 0,
+        requestPerMinute: 10,
+        requestPerDay: 1000,
+    });
+    const [apiKeys, setApiKeys] = useState<LlmApiKey[]>([]);
+    const [models, setModels] = useState<LlmModel[]>([]);
+    const [loadingApiKeys, setLoadingApiKeys] = useState(false);
+    const [loadingModels, setLoadingModels] = useState(false);
+
+    const isEditMode = !!relation;
+
+    // Fetch API keys on mount
+    useEffect(() => {
+        const fetchApiKeys = async () => {
+            try {
+                setLoadingApiKeys(true);
+                const response: ApiResponse<LlmApiKeysResponse> = await getRequest<unknown, LlmApiKeysResponse>(
+                    ROUTES.LLM_API_KEYS_LIST('limit=100')
+                );
+                setApiKeys(response.data?.apiKeys || []);
+            } catch (error) {
+                console.error('Failed to fetch API keys:', error);
+                toast({
+                    description: 'Failed to load API keys list',
+                    variant: 'destructive',
+                });
+            } finally {
+                setLoadingApiKeys(false);
+            }
+        };
+
+        if (open) {
+            fetchApiKeys();
+        }
+    }, [open]);
+
+    // Fetch models on mount
+    useEffect(() => {
+        const fetchModels = async () => {
+            try {
+                setLoadingModels(true);
+                const response: ApiResponse<LlmModelsResponse> = await getRequest<unknown, LlmModelsResponse>(
+                    ROUTES.LLM_MODELS_LIST('limit=100')
+                );
+                setModels(response.data?.models || []);
+            } catch (error) {
+                console.error('Failed to fetch models:', error);
+                toast({
+                    description: 'Failed to load models list',
+                    variant: 'destructive',
+                });
+            } finally {
+                setLoadingModels(false);
+            }
+        };
+
+        if (open) {
+            fetchModels();
+        }
+    }, [open]);
+
+    // Initialize form data when relation changes
+    useEffect(() => {
+        if (relation) {
+            setFormData({
+                apiKeyId: relation.apiKeyId,
+                modelId: relation.modelId,
+                requestPerMinute: relation.requestPerMinute,
+                requestPerDay: relation.requestPerDay,
+            });
+        } else {
+            resetForm();
+        }
+    }, [relation]);
+
+    const resetForm = () => {
+        setFormData({
+            apiKeyId: 0,
+            modelId: 0,
+            requestPerMinute: 10,
+            requestPerDay: 1000,
+        });
+    };
+
+    const { execute: createRelation, loading: createLoading } = usePost(
+        ROUTES.LLM_API_KEY_MODELS_CREATE,
+        'POST',
+        {
+            onError: (error) => {
+                const errorMessage = errorHelper.getErrorMessage(error);
+                toast({
+                    description: errorMessage || 'Failed to create relation',
+                    variant: 'destructive',
+                });
+            },
+            onMessageSuccess: () => {
+                toast({ description: 'Relation created successfully' });
+                onSuccess();
+            },
+        }
+    );
+
+    const { execute: updateRelation, loading: updateLoading } = usePost(
+        ROUTES.LLM_API_KEY_MODELS_UPDATE(relation?.id || 0),
+        'PATCH',
+        {
+            onError: (error) => {
+                const errorMessage = errorHelper.getErrorMessage(error);
+                toast({
+                    description: errorMessage || 'Failed to update relation',
+                    variant: 'destructive',
+                });
+            },
+            onMessageSuccess: () => {
+                toast({ description: 'Relation updated successfully' });
+                onSuccess();
+            },
+        }
+    );
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (!formData.apiKeyId || formData.apiKeyId === 0) {
+            toast({
+                description: 'Please select an API key',
+                variant: 'destructive',
+            });
+            return;
+        }
+
+        if (!formData.modelId || formData.modelId === 0) {
+            toast({
+                description: 'Please select a model',
+                variant: 'destructive',
+            });
+            return;
+        }
+
+        if (formData.requestPerMinute <= 0) {
+            toast({
+                description: 'Request per minute must be greater than 0',
+                variant: 'destructive',
+            });
+            return;
+        }
+
+        if (formData.requestPerDay <= 0) {
+            toast({
+                description: 'Request per day must be greater than 0',
+                variant: 'destructive',
+            });
+            return;
+        }
+
+        if (isEditMode) {
+            const updatePayload: UpdateLlmApiKeyModelInput = {
+                apiKeyId: formData.apiKeyId,
+                modelId: formData.modelId,
+                requestPerMinute: formData.requestPerMinute,
+                requestPerDay: formData.requestPerDay,
+            };
+            await updateRelation(updatePayload);
+        } else {
+            const createPayload: CreateLlmApiKeyModelInput = {
+                apiKeyId: formData.apiKeyId,
+                modelId: formData.modelId,
+                requestPerMinute: formData.requestPerMinute,
+                requestPerDay: formData.requestPerDay,
+            };
+            await createRelation(createPayload);
+        }
+    };
+
+    const loading = createLoading || updateLoading;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>{isEditMode ? 'Edit Relation' : 'Create Relation'}</DialogTitle>
+                    <DialogDescription>
+                        {isEditMode
+                            ? 'Update the API key-model relation information below.'
+                            : 'Link an API key to a model and set rate limits.'}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="apiKeyId">
+                                API Key <span className="text-destructive">*</span>
+                            </Label>
+                            <Select
+                                value={formData.apiKeyId.toString()}
+                                onValueChange={(value) => setFormData({ ...formData, apiKeyId: parseInt(value, 10) })}
+                                disabled={loading || loadingApiKeys}
+                            >
+                                <SelectTrigger id="apiKeyId">
+                                    <SelectValue placeholder="Select an API key" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {apiKeys.map((apiKey) => {
+                                        const maskedKey = apiKey.keyValue.length > 12 
+                                            ? `${apiKey.keyValue.substring(0, 8)}...${apiKey.keyValue.substring(apiKey.keyValue.length - 4)}`
+                                            : '***';
+                                        return (
+                                            <SelectItem key={apiKey.keyId} value={apiKey.keyId.toString()}>
+                                                {apiKey.providerName || `Provider ${apiKey.providerId}`} - {maskedKey}
+                                            </SelectItem>
+                                        );
+                                    })}
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="modelId">
+                                Model <span className="text-destructive">*</span>
+                            </Label>
+                            <Select
+                                value={formData.modelId.toString()}
+                                onValueChange={(value) => setFormData({ ...formData, modelId: parseInt(value, 10) })}
+                                disabled={loading || loadingModels}
+                            >
+                                <SelectTrigger id="modelId">
+                                    <SelectValue placeholder="Select a model" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {models.map((model) => (
+                                        <SelectItem key={model.modelId} value={model.modelId.toString()}>
+                                            {model.providerName || `Provider ${model.providerId}`} - {model.name}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="requestPerMinute">
+                                Requests Per Minute <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="requestPerMinute"
+                                type="number"
+                                min="1"
+                                value={formData.requestPerMinute}
+                                onChange={(e) => setFormData({ ...formData, requestPerMinute: parseInt(e.target.value, 10) || 0 })}
+                                disabled={loading}
+                                required
+                            />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="requestPerDay">
+                                Requests Per Day <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="requestPerDay"
+                                type="number"
+                                min="1"
+                                value={formData.requestPerDay}
+                                onChange={(e) => setFormData({ ...formData, requestPerDay: parseInt(e.target.value, 10) || 0 })}
+                                disabled={loading}
+                                required
+                            />
+                        </div>
+                    </div>
+
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={loading}>
+                            {loading ? 'Saving...' : isEditMode ? 'Update' : 'Create'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+

--- a/src/app/[locale]/admin/llm-api-key-models/components/DeleteApiKeyModelDialog.tsx
+++ b/src/app/[locale]/admin/llm-api-key-models/components/DeleteApiKeyModelDialog.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { LlmApiKeyModel } from '@/types/llm-admin/llmApiKeyModel';
+import { DeleteConfirmationDialog, DeleteConfirmationDialogConfig } from '@/components/admin/DeleteConfirmationDialog';
+import { getProviderBadgeClass } from '@/utils/providerColors';
+import { Badge } from '@/components/ui/badge';
+import { ROUTES } from '@/utils/constants/routes';
+
+interface DeleteApiKeyModelDialogProps {
+    relation: LlmApiKeyModel;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: () => void;
+}
+
+export function DeleteApiKeyModelDialog({ relation, open, onOpenChange, onSuccess }: DeleteApiKeyModelDialogProps) {
+    const config: DeleteConfirmationDialogConfig<LlmApiKeyModel> = {
+        entity: relation,
+        entityName: 'Relation',
+        entityDisplayName: `Relation ${relation.id}`,
+        entityId: relation.id,
+        endpoint: ROUTES.LLM_API_KEY_MODELS_DELETE(relation.id),
+        description:
+            'This action cannot be undone. This will permanently delete the API key-model relation.',
+        renderInfoFields: (relation) => (
+            <>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Relation ID:</span>
+                    <span className="font-medium">{relation.id}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Provider:</span>
+                    <Badge className={getProviderBadgeClass(relation.providerName || 'Unknown')}>
+                        {relation.providerName || 'Unknown'}
+                    </Badge>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Model:</span>
+                    <span className="font-medium">{relation.modelName || `Model ${relation.modelId}`}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">API Key ID:</span>
+                    <span className="font-mono text-xs">{relation.apiKeyId}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Requests/Min:</span>
+                    <span className="font-medium">{relation.requestPerMinute}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Requests/Day:</span>
+                    <span className="font-medium">{relation.requestPerDay}</span>
+                </div>
+            </>
+        ),
+        warningMessages: [
+            'This will remove the rate limit configuration for this API key-model pair',
+            'This action is permanent and cannot be reversed',
+        ],
+        successMessage: 'Relation deleted successfully',
+        errorMessage: 'Failed to delete relation',
+        deleteButtonText: 'Delete Relation',
+    };
+
+    return (
+        <DeleteConfirmationDialog
+            open={open}
+            onOpenChange={onOpenChange}
+            onSuccess={onSuccess}
+            config={config}
+        />
+    );
+}
+

--- a/src/app/[locale]/admin/llm-api-key-models/page.tsx
+++ b/src/app/[locale]/admin/llm-api-key-models/page.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { withAuth } from '@/hoc/withAuth';
+import { getRequest } from '@/api/api';
+import { ApiResponse } from '@/api/type';
+import { LlmApiKeyModel, LlmApiKeyModelsResponse, GetLlmApiKeyModelsQuery } from '@/types/llm-admin/llmApiKeyModel';
+import { ROUTES } from '@/utils/constants/routes';
+import { DataTable } from '@/components/ui/data-table';
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
+import { getLlmApiKeyModelColumns } from './components/Columns';
+import { CreateEditLlmApiKeyModelDialog } from './components/CreateEditLlmApiKeyModelDialog';
+
+function AdminLlmApiKeyModelsPage() {
+    const [filters, setFilters] = useState<GetLlmApiKeyModelsQuery>({});
+    const [relations, setRelations] = useState<LlmApiKeyModel[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [total, setTotal] = useState(0);
+    const [createDialogOpen, setCreateDialogOpen] = useState(false);
+    const [editingRelation, setEditingRelation] = useState<LlmApiKeyModel | null>(null);
+
+    const fetchRelations = useCallback(
+        async (params: GetLlmApiKeyModelsQuery) => {
+            try {
+                setLoading(true);
+                setError(null);
+
+                const query = new URLSearchParams(
+                    Object.entries(params).reduce((acc, [key, value]) => {
+                        if (value !== undefined && value !== null && value !== '') {
+                            acc[key] = String(value);
+                        }
+                        return acc;
+                    }, {} as Record<string, string>)
+                ).toString();
+
+                const url = ROUTES.LLM_API_KEY_MODELS_LIST(query);
+                const response: ApiResponse<LlmApiKeyModelsResponse> = await getRequest<unknown, LlmApiKeyModelsResponse>(url);
+                
+                if (response.data) {
+                    setRelations(response.data.relations || []);
+                    setTotal(response.data.total || 0);
+                } else {
+                    setRelations([]);
+                    setTotal(0);
+                }
+            } catch (err: any) {
+                setError(err.message || 'An error occurred while retrieving API key-model relations.');
+            } finally {
+                setLoading(false);
+            }
+        },
+        [],
+    );
+
+    useEffect(() => {
+        fetchRelations(filters);
+    }, [fetchRelations, filters]);
+
+    const handleFilterChange = (newFilters: GetLlmApiKeyModelsQuery) => {
+        setFilters(newFilters);
+    };
+
+    const refetch = useCallback(() => {
+        fetchRelations(filters);
+    }, [fetchRelations, filters]);
+
+    const handleEdit = (relation: LlmApiKeyModel) => {
+        setEditingRelation(relation);
+    };
+
+    const handleDialogClose = () => {
+        setCreateDialogOpen(false);
+        setEditingRelation(null);
+    };
+
+    const handleSuccess = () => {
+        refetch();
+        handleDialogClose();
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center justify-between">
+                <div className="space-y-1">
+                    <h2 className="text-2xl font-bold tracking-tight">LLM API Key-Model Relations Management</h2>
+                    <p className="text-muted-foreground">
+                        Manage relations between API keys and models
+                    </p>
+                </div>
+                <Button onClick={() => setCreateDialogOpen(true)}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create Relation
+                </Button>
+            </div>
+
+            <DataTable
+                columns={getLlmApiKeyModelColumns(refetch, handleEdit)}
+                data={relations}
+                loading={loading}
+                error={error}
+                title={`Relations (${total})`}
+            />
+
+            <CreateEditLlmApiKeyModelDialog
+                open={createDialogOpen || editingRelation !== null}
+                onOpenChange={handleDialogClose}
+                onSuccess={handleSuccess}
+                relation={editingRelation}
+            />
+        </div>
+    );
+}
+
+export default withAuth(AdminLlmApiKeyModelsPage, {
+    requiredRole: 'admin',
+});
+

--- a/src/app/[locale]/admin/llm-api-keys/components/Columns.tsx
+++ b/src/app/[locale]/admin/llm-api-keys/components/Columns.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import { LlmApiKey } from '@/types/llm-admin/llmApiKey';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import usePost from '@/hooks/usePost';
+import { toast } from '@/hooks/use-toast';
+import { Edit, Trash2, Power } from 'lucide-react';
+import { ROUTES } from '@/utils/constants/routes';
+import { useState } from 'react';
+import { getProviderColor } from '@/utils/providerColors';
+import { DeleteApiKeyDialog } from './DeleteApiKeyDialog';
+
+function ActionButtons({
+    apiKey,
+    refetch,
+    onEdit,
+}: {
+    apiKey: LlmApiKey;
+    refetch: () => void;
+    onEdit: (apiKey: LlmApiKey) => void;
+}) {
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+    const { execute: toggleStatus, loading: toggleLoading } = usePost(
+        ROUTES.LLM_API_KEYS_TOGGLE_STATUS(apiKey.keyId),
+        'PATCH',
+        {
+            onMessageError: () =>
+                toast({ description: 'Failed to toggle status', variant: 'destructive' }),
+            onMessageSuccess: () => {
+                toast({ description: 'Status toggled successfully' });
+                refetch();
+            },
+        }
+    );
+
+    const handleToggleStatus = async () => {
+        await toggleStatus({});
+    };
+
+    const handleDeleteSuccess = () => {
+        refetch();
+    };
+
+    return (
+        <>
+            <div className="flex gap-2">
+                <Button variant="outline" size="sm" onClick={() => onEdit(apiKey)} title="Edit API key">
+                    <Edit className="h-4 w-4" />
+                </Button>
+                <Button
+                    variant={apiKey.status === 'active' ? 'secondary' : 'default'}
+                    size="sm"
+                    onClick={handleToggleStatus}
+                    disabled={toggleLoading}
+                    title={apiKey.status === 'active' ? 'Deactivate' : 'Activate'}
+                >
+                    <Power className="h-4 w-4" />
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setDeleteDialogOpen(true)}
+                    title="Delete API key"
+                    className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                >
+                    <Trash2 className="h-4 w-4" />
+                </Button>
+            </div>
+
+            <DeleteApiKeyDialog
+                apiKey={apiKey}
+                open={deleteDialogOpen}
+                onOpenChange={setDeleteDialogOpen}
+                onSuccess={handleDeleteSuccess}
+            />
+        </>
+    );
+}
+
+const getStatusBadge = (status: LlmApiKey['status']) => {
+    const variants: Record<LlmApiKey['status'], { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }> = {
+        active: { variant: 'default', label: 'Active' },
+        inactive: { variant: 'secondary', label: 'Inactive' },
+        expired: { variant: 'destructive', label: 'Expired' },
+        rate_limited: { variant: 'outline', label: 'Rate Limited' },
+    };
+    const config = variants[status];
+    return <Badge variant={config.variant}>{config.label}</Badge>;
+};
+
+const getKeyTypeBadge = (keyType: LlmApiKey['keyType']) => {
+    return (
+        <Badge variant={keyType === 'paid' ? 'default' : 'secondary'}>
+            {keyType === 'paid' ? 'Paid' : 'Free'}
+        </Badge>
+    );
+};
+
+export const getLlmApiKeyColumns = (
+    refetch: () => void,
+    onEdit: (apiKey: LlmApiKey) => void
+): ColumnDef<LlmApiKey>[] => [
+    {
+        accessorKey: 'keyId',
+        header: 'ID',
+        size: 60,
+    },
+    {
+        accessorKey: 'providerName',
+        header: 'Provider',
+        cell: ({ row }) => {
+            const providerName = row.original.providerName || `Provider ${row.original.providerId}`;
+            const colors = getProviderColor(providerName);
+            return (
+                <Badge 
+                    className="text-white border-0"
+                    style={{
+                        background: `linear-gradient(to right, ${colors.gradientFrom}, ${colors.gradientTo})`,
+                    }}
+                >
+                    {providerName}
+                </Badge>
+            );
+        },
+    },
+    {
+        accessorKey: 'keyValue',
+        header: 'API Key',
+        cell: ({ row }) => {
+            const keyValue = row.original.keyValue;
+            // Mask the key for security (show first 8 and last 4 characters)
+            const masked = keyValue.length > 12 
+                ? `${keyValue.substring(0, 8)}...${keyValue.substring(keyValue.length - 4)}`
+                : '***';
+            return (
+                <div className="font-mono text-sm">
+                    {masked}
+                </div>
+            );
+        },
+    },
+    {
+        accessorKey: 'keyType',
+        header: 'Type',
+        cell: ({ row }) => getKeyTypeBadge(row.original.keyType),
+    },
+    {
+        accessorKey: 'status',
+        header: 'Status',
+        cell: ({ row }) => getStatusBadge(row.original.status),
+    },
+    {
+        accessorKey: 'priority',
+        header: 'Priority',
+        cell: ({ row }) => <span className="font-mono">{row.original.priority}</span>,
+    },
+    {
+        accessorKey: 'isDefault',
+        header: 'Default',
+        cell: ({ row }) => (
+            <Badge variant={row.original.isDefault ? 'default' : 'outline'}>
+                {row.original.isDefault ? 'Yes' : 'No'}
+            </Badge>
+        ),
+    },
+    {
+        accessorKey: 'usageLimitPerDay',
+        header: 'Usage Limit/Day',
+        cell: ({ row }) => (
+            <span className="text-sm">
+                {row.original.usageLimitPerDay ?? 'Unlimited'}
+            </span>
+        ),
+    },
+    {
+        accessorKey: 'createdAt',
+        header: 'Created At',
+        cell: ({ row }) => {
+            const date = new Date(row.original.createdAt);
+            return <span className="text-sm text-muted-foreground">{date.toLocaleDateString()}</span>;
+        },
+    },
+    {
+        id: 'action',
+        header: 'Actions',
+        cell: ({ row }) => <ActionButtons apiKey={row.original} refetch={refetch} onEdit={onEdit} />,
+    },
+];
+

--- a/src/app/[locale]/admin/llm-api-keys/components/CreateEditLlmApiKeyDialog.tsx
+++ b/src/app/[locale]/admin/llm-api-keys/components/CreateEditLlmApiKeyDialog.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import usePost from '@/hooks/usePost';
+import { toast } from '@/hooks/use-toast';
+import { CreateLlmApiKeyInput, UpdateLlmApiKeyInput, LlmApiKey } from '@/types/llm-admin/llmApiKey';
+import { LlmProvider, LlmProvidersResponse } from '@/types/llm-admin/llmProvider';
+import errorHelper from '@/utils/error.helper';
+import { getRequest } from '@/api/api';
+import { ApiResponse } from '@/api/type';
+import { ROUTES } from '@/utils/constants/routes';
+
+interface CreateEditLlmApiKeyDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: () => void;
+    apiKey?: LlmApiKey | null;
+}
+
+export function CreateEditLlmApiKeyDialog({
+    open,
+    onOpenChange,
+    onSuccess,
+    apiKey,
+}: CreateEditLlmApiKeyDialogProps) {
+    const [formData, setFormData] = useState<CreateLlmApiKeyInput & { index?: number }>({
+        providerId: 0,
+        isDefault: false,
+        priority: 0,
+        index: 0,
+        keyValue: '',
+        keyType: 'free',
+        status: 'active',
+        usageLimitPerDay: null,
+    });
+    const [providers, setProviders] = useState<LlmProvider[]>([]);
+    const [loadingProviders, setLoadingProviders] = useState(false);
+
+    const isEditMode = !!apiKey;
+
+    // Fetch providers on mount
+    useEffect(() => {
+        const fetchProviders = async () => {
+            try {
+                setLoadingProviders(true);
+                const response: ApiResponse<LlmProvidersResponse> = await getRequest<unknown, LlmProvidersResponse>(
+                    ROUTES.LLM_PROVIDERS_LIST_ALL
+                );
+                setProviders(response.data?.providers || []);
+            } catch (error) {
+                console.error('Failed to fetch providers:', error);
+                toast({
+                    description: 'Failed to load providers list',
+                    variant: 'destructive',
+                });
+            } finally {
+                setLoadingProviders(false);
+            }
+        };
+
+        if (open) {
+            fetchProviders();
+        }
+    }, [open]);
+
+    // Initialize form data when apiKey changes
+    useEffect(() => {
+        if (apiKey) {
+            setFormData({
+                providerId: apiKey.providerId,
+                isDefault: apiKey.isDefault,
+                priority: apiKey.priority,
+                index: apiKey.index,
+                keyValue: apiKey.keyValue,
+                keyType: apiKey.keyType,
+                status: apiKey.status,
+                usageLimitPerDay: apiKey.usageLimitPerDay,
+            });
+        } else {
+            resetForm();
+        }
+    }, [apiKey]);
+
+    const resetForm = () => {
+        setFormData({
+            providerId: 0,
+            isDefault: false,
+            priority: 0,
+            index: 0,
+            keyValue: '',
+            keyType: 'free',
+            status: 'active',
+            usageLimitPerDay: null,
+        });
+    };
+
+    const { execute: createApiKey, loading: createLoading } = usePost(
+        ROUTES.LLM_API_KEYS_CREATE,
+        'POST',
+        {
+            onError: (error) => {
+                const errorMessage = errorHelper.getErrorMessage(error);
+                toast({
+                    description: errorMessage || 'Failed to create API key',
+                    variant: 'destructive',
+                });
+            },
+            onMessageSuccess: () => {
+                toast({ description: 'API key created successfully' });
+                onSuccess();
+            },
+        }
+    );
+
+    const { execute: updateApiKey, loading: updateLoading } = usePost(
+        ROUTES.LLM_API_KEYS_UPDATE(apiKey?.keyId || 0),
+        'PATCH',
+        {
+            onError: (error) => {
+                const errorMessage = errorHelper.getErrorMessage(error);
+                toast({
+                    description: errorMessage || 'Failed to update API key',
+                    variant: 'destructive',
+                });
+            },
+            onMessageSuccess: () => {
+                toast({ description: 'API key updated successfully' });
+                onSuccess();
+            },
+        }
+    );
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (!formData.providerId || formData.providerId === 0) {
+            toast({
+                description: 'Please select a provider',
+                variant: 'destructive',
+            });
+            return;
+        }
+
+        if (!formData.keyValue.trim()) {
+            toast({
+                description: 'Please enter an API key value',
+                variant: 'destructive',
+            });
+            return;
+        }
+
+        if (isEditMode) {
+            const updatePayload: UpdateLlmApiKeyInput = {
+                providerId: formData.providerId,
+                isDefault: formData.isDefault,
+                priority: formData.priority,
+                index: formData.index,
+                keyValue: formData.keyValue,
+                keyType: formData.keyType,
+                status: formData.status,
+                usageLimitPerDay: formData.usageLimitPerDay,
+            };
+            await updateApiKey(updatePayload);
+        } else {
+            const createPayload: CreateLlmApiKeyInput = {
+                providerId: formData.providerId,
+                isDefault: formData.isDefault,
+                priority: formData.priority,
+                index: formData.index || 0,
+                keyValue: formData.keyValue,
+                keyType: formData.keyType,
+                status: formData.status,
+                usageLimitPerDay: formData.usageLimitPerDay,
+            };
+            await createApiKey(createPayload);
+        }
+    };
+
+    const loading = createLoading || updateLoading;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+                <DialogHeader>
+                    <DialogTitle>{isEditMode ? 'Edit API Key' : 'Create API Key'}</DialogTitle>
+                    <DialogDescription>
+                        {isEditMode
+                            ? 'Update the API key information below.'
+                            : 'Fill in the details to create a new API key for an LLM provider.'}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="providerId">
+                            Provider <span className="text-destructive">*</span>
+                        </Label>
+                        <Select
+                            value={formData.providerId.toString()}
+                            onValueChange={(value) => setFormData({ ...formData, providerId: parseInt(value, 10) })}
+                            disabled={loading || loadingProviders}
+                        >
+                            <SelectTrigger id="providerId">
+                                <SelectValue placeholder="Select a provider" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {providers.map((provider) => (
+                                    <SelectItem key={provider.providerId} value={provider.providerId.toString()}>
+                                        {provider.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="keyValue">
+                            API Key Value <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="keyValue"
+                            type="password"
+                            value={formData.keyValue}
+                            onChange={(e) => setFormData({ ...formData, keyValue: e.target.value })}
+                            placeholder="Enter API key value"
+                            disabled={loading}
+                            required
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="keyType">Key Type</Label>
+                            <Select
+                                value={formData.keyType}
+                                onValueChange={(value: 'free' | 'paid') =>
+                                    setFormData({ ...formData, keyType: value })
+                                }
+                                disabled={loading}
+                            >
+                                <SelectTrigger id="keyType">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="free">Free</SelectItem>
+                                    <SelectItem value="paid">Paid</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="status">Status</Label>
+                            <Select
+                                value={formData.status}
+                                onValueChange={(value: 'active' | 'inactive' | 'expired' | 'rate_limited') =>
+                                    setFormData({ ...formData, status: value })
+                                }
+                                disabled={loading}
+                            >
+                                <SelectTrigger id="status">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="active">Active</SelectItem>
+                                    <SelectItem value="inactive">Inactive</SelectItem>
+                                    <SelectItem value="expired">Expired</SelectItem>
+                                    <SelectItem value="rate_limited">Rate Limited</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-3 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="priority">Priority</Label>
+                            <Input
+                                id="priority"
+                                type="number"
+                                value={formData.priority}
+                                onChange={(e) => setFormData({ ...formData, priority: parseInt(e.target.value, 10) || 0 })}
+                                disabled={loading}
+                            />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="index">Index</Label>
+                            <Input
+                                id="index"
+                                type="number"
+                                value={formData.index}
+                                onChange={(e) => setFormData({ ...formData, index: parseInt(e.target.value, 10) || 0 })}
+                                disabled={loading}
+                                required
+                            />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="usageLimitPerDay">Usage Limit/Day</Label>
+                            <Input
+                                id="usageLimitPerDay"
+                                type="number"
+                                value={formData.usageLimitPerDay || ''}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        usageLimitPerDay: e.target.value ? parseInt(e.target.value, 10) : null,
+                                    })
+                                }
+                                placeholder="Unlimited"
+                                disabled={loading}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex items-center space-x-2">
+                        <Switch
+                            id="isDefault"
+                            checked={formData.isDefault}
+                            onCheckedChange={(checked) => setFormData({ ...formData, isDefault: checked })}
+                            disabled={loading}
+                        />
+                        <Label htmlFor="isDefault" className="cursor-pointer">
+                            Set as default API key
+                        </Label>
+                    </div>
+
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={loading}>
+                            {loading ? 'Saving...' : isEditMode ? 'Update' : 'Create'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+

--- a/src/app/[locale]/admin/llm-api-keys/components/DeleteApiKeyDialog.tsx
+++ b/src/app/[locale]/admin/llm-api-keys/components/DeleteApiKeyDialog.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { LlmApiKey } from '@/types/llm-admin/llmApiKey';
+import { DeleteConfirmationDialog, DeleteConfirmationDialogConfig } from '@/components/admin/DeleteConfirmationDialog';
+import { getProviderBadgeClass } from '@/utils/providerColors';
+import { Badge } from '@/components/ui/badge';
+import { ROUTES } from '@/utils/constants/routes';
+
+interface DeleteApiKeyDialogProps {
+    apiKey: LlmApiKey;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: () => void;
+}
+
+export function DeleteApiKeyDialog({ apiKey, open, onOpenChange, onSuccess }: DeleteApiKeyDialogProps) {
+    const maskedKey = apiKey.keyValue.length > 12 
+        ? `${apiKey.keyValue.substring(0, 8)}...${apiKey.keyValue.substring(apiKey.keyValue.length - 4)}`
+        : '***';
+
+    const config: DeleteConfirmationDialogConfig<LlmApiKey> = {
+        entity: apiKey,
+        entityName: 'API Key',
+        entityDisplayName: `API Key ${apiKey.keyId}`,
+        entityId: apiKey.keyId,
+        endpoint: ROUTES.LLM_API_KEYS_DELETE(apiKey.keyId),
+        description:
+            'This action cannot be undone. This will permanently delete the API key and may affect related model configurations.',
+        renderInfoFields: (apiKey) => (
+            <>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Key ID:</span>
+                    <span className="font-medium">{apiKey.keyId}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Provider:</span>
+                    <Badge className={getProviderBadgeClass(apiKey.providerName || `Provider ${apiKey.providerId}`)}>
+                        {apiKey.providerName || `Provider ${apiKey.providerId}`}
+                    </Badge>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">API Key:</span>
+                    <span className="font-mono text-xs">{maskedKey}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Type:</span>
+                    <span className="font-medium">{apiKey.keyType === 'paid' ? 'Paid' : 'Free'}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Status:</span>
+                    <span className="font-medium">{apiKey.status}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Priority:</span>
+                    <span className="font-medium">{apiKey.priority}</span>
+                </div>
+                {apiKey.usageLimitPerDay && (
+                    <div className="flex justify-between text-sm">
+                        <span className="text-muted-foreground">Usage Limit/Day:</span>
+                        <span className="font-medium">{apiKey.usageLimitPerDay}</span>
+                    </div>
+                )}
+            </>
+        ),
+        warningMessages: [
+            'Model relations linked to this API key may become invalid',
+            'This action is permanent and cannot be reversed',
+        ],
+        successMessage: 'API key deleted successfully',
+        errorMessage: 'Failed to delete API key',
+        deleteButtonText: 'Delete API Key',
+    };
+
+    return (
+        <DeleteConfirmationDialog
+            open={open}
+            onOpenChange={onOpenChange}
+            onSuccess={onSuccess}
+            config={config}
+        />
+    );
+}
+

--- a/src/app/[locale]/admin/llm-api-keys/page.tsx
+++ b/src/app/[locale]/admin/llm-api-keys/page.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { withAuth } from '@/hoc/withAuth';
+import { getRequest } from '@/api/api';
+import { ApiResponse } from '@/api/type';
+import { LlmApiKey, LlmApiKeysResponse, GetLlmApiKeysQuery } from '@/types/llm-admin/llmApiKey';
+import { ROUTES } from '@/utils/constants/routes';
+import { DataTable } from '@/components/ui/data-table';
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
+import { getLlmApiKeyColumns } from './components/Columns';
+import { CreateEditLlmApiKeyDialog } from './components/CreateEditLlmApiKeyDialog';
+
+function AdminLlmApiKeysPage() {
+    const [filters, setFilters] = useState<GetLlmApiKeysQuery>({});
+    const [apiKeys, setApiKeys] = useState<LlmApiKey[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [total, setTotal] = useState(0);
+    const [createDialogOpen, setCreateDialogOpen] = useState(false);
+    const [editingApiKey, setEditingApiKey] = useState<LlmApiKey | null>(null);
+
+    const fetchApiKeys = useCallback(
+        async (params: GetLlmApiKeysQuery) => {
+            try {
+                setLoading(true);
+                setError(null);
+
+                const query = new URLSearchParams(
+                    Object.entries(params).reduce((acc, [key, value]) => {
+                        if (value !== undefined && value !== null && value !== '') {
+                            acc[key] = String(value);
+                        }
+                        return acc;
+                    }, {} as Record<string, string>)
+                ).toString();
+
+                const url = ROUTES.LLM_API_KEYS_LIST(query);
+                const response: ApiResponse<LlmApiKeysResponse> = await getRequest<unknown, LlmApiKeysResponse>(url);
+                
+                if (response.data) {
+                    setApiKeys(response.data.apiKeys || []);
+                    setTotal(response.data.total || 0);
+                } else {
+                    setApiKeys([]);
+                    setTotal(0);
+                }
+            } catch (err: any) {
+                setError(err.message || 'An error occurred while retrieving API keys.');
+            } finally {
+                setLoading(false);
+            }
+        },
+        [],
+    );
+
+    useEffect(() => {
+        fetchApiKeys(filters);
+    }, [fetchApiKeys, filters]);
+
+    const handleFilterChange = (newFilters: GetLlmApiKeysQuery) => {
+        setFilters(newFilters);
+    };
+
+    const refetch = useCallback(() => {
+        fetchApiKeys(filters);
+    }, [fetchApiKeys, filters]);
+
+    const handleEdit = (apiKey: LlmApiKey) => {
+        setEditingApiKey(apiKey);
+    };
+
+    const handleDialogClose = () => {
+        setCreateDialogOpen(false);
+        setEditingApiKey(null);
+    };
+
+    const handleSuccess = () => {
+        refetch();
+        handleDialogClose();
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center justify-between">
+                <div className="space-y-1">
+                    <h2 className="text-2xl font-bold tracking-tight">LLM API Keys Management</h2>
+                    <p className="text-muted-foreground">
+                        Manage API keys for LLM providers
+                    </p>
+                </div>
+                <Button onClick={() => setCreateDialogOpen(true)}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create API Key
+                </Button>
+            </div>
+
+            <DataTable
+                columns={getLlmApiKeyColumns(refetch, handleEdit)}
+                data={apiKeys}
+                loading={loading}
+                error={error}
+                title={`API Keys (${total})`}
+            />
+
+            <CreateEditLlmApiKeyDialog
+                open={createDialogOpen || editingApiKey !== null}
+                onOpenChange={handleDialogClose}
+                onSuccess={handleSuccess}
+                apiKey={editingApiKey}
+            />
+        </div>
+    );
+}
+
+export default withAuth(AdminLlmApiKeysPage, {
+    requiredRole: 'admin',
+});
+

--- a/src/components/admin/Sidebar.tsx
+++ b/src/components/admin/Sidebar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import AuthButton from '@/components/toolbar/AuthButton';
-import { Home, Users, BarChart3, Clock, ListChecks, CreditCard, Star, TrendingUp, DollarSign, Wallet, Brain, Server } from 'lucide-react';
+import { Home, Users, BarChart3, Clock, ListChecks, CreditCard, Star, TrendingUp, DollarSign, Wallet, Brain, Server, Key, Link as LinkIcon } from 'lucide-react';
 
 interface SidebarProps {
     className?: string;
@@ -57,6 +57,16 @@ const navItems = [
         label: 'LLM Providers',
         icon: Server,
         href: '/admin/llm-providers'
+    },
+    {
+        label: 'LLM API Keys',
+        icon: Key,
+        href: '/admin/llm-api-keys'
+    },
+    {
+        label: 'LLM API Key-Models',
+        icon: LinkIcon,
+        href: '/admin/llm-api-key-models'
     },
     {
         label: 'Stats',

--- a/src/types/llm-admin/llmApiKey.ts
+++ b/src/types/llm-admin/llmApiKey.ts
@@ -1,0 +1,54 @@
+export interface LlmApiKey {
+  keyId: number;
+  providerId: number;
+  providerName?: string;
+  isDefault: boolean;
+  priority: number;
+  index: number;
+  keyValue: string;
+  keyType: 'free' | 'paid';
+  status: 'active' | 'inactive' | 'expired' | 'rate_limited';
+  usageLimitPerDay?: number | null;
+  createdAt: string;
+}
+
+export interface CreateLlmApiKeyInput {
+  providerId: number;
+  isDefault?: boolean;
+  priority?: number;
+  index: number;
+  keyValue: string;
+  keyType: 'free' | 'paid';
+  status?: 'active' | 'inactive' | 'expired' | 'rate_limited';
+  usageLimitPerDay?: number | null;
+}
+
+export interface UpdateLlmApiKeyInput {
+  providerId?: number;
+  isDefault?: boolean;
+  priority?: number;
+  index?: number;
+  keyValue?: string;
+  keyType?: 'free' | 'paid';
+  status?: 'active' | 'inactive' | 'expired' | 'rate_limited';
+  usageLimitPerDay?: number | null;
+}
+
+export interface GetLlmApiKeysQuery {
+  providerId?: string;
+  providerName?: string;
+  status?: 'active' | 'inactive' | 'expired' | 'rate_limited' | '';
+  keyType?: 'free' | 'paid' | '';
+  isDefault?: 'true' | 'false' | '';
+  page?: string;
+  limit?: string;
+  search?: string;
+}
+
+export interface LlmApiKeysResponse {
+  apiKeys: LlmApiKey[];
+  total: number;
+  page: number;
+  limit: number;
+}
+

--- a/src/types/llm-admin/llmApiKeyModel.ts
+++ b/src/types/llm-admin/llmApiKeyModel.ts
@@ -1,0 +1,40 @@
+export interface LlmApiKeyModel {
+  id: number;
+  apiKeyId: number;
+  modelId: number;
+  modelName?: string;
+  providerName?: string;
+  requestPerMinute: number;
+  requestPerDay: number;
+  createdAt: string;
+}
+
+export interface CreateLlmApiKeyModelInput {
+  apiKeyId: number;
+  modelId: number;
+  requestPerMinute: number;
+  requestPerDay: number;
+}
+
+export interface UpdateLlmApiKeyModelInput {
+  apiKeyId?: number;
+  modelId?: number;
+  requestPerMinute?: number;
+  requestPerDay?: number;
+}
+
+export interface GetLlmApiKeyModelsQuery {
+  apiKeyId?: string;
+  modelId?: string;
+  providerId?: string;
+  page?: string;
+  limit?: string;
+}
+
+export interface LlmApiKeyModelsResponse {
+  relations: LlmApiKeyModel[];
+  total: number;
+  page: number;
+  limit: number;
+}
+

--- a/src/utils/constants/routes.ts
+++ b/src/utils/constants/routes.ts
@@ -55,6 +55,21 @@ export const ROUTES = Object.freeze({
     LLM_PROVIDERS_DELETE: (id: string | number) => `/admin/llm-providers/${id}`,
     LLM_PROVIDERS_TOGGLE_AVAILABILITY: (id: string | number) => `/admin/llm-providers/${id}/toggle-availability`,
 
+    // LLM API Keys
+    LLM_API_KEYS: '/admin/llm-api-keys',
+    LLM_API_KEYS_LIST: (query?: string) => (query ? `/admin/llm-api-keys?${query}` : '/admin/llm-api-keys'),
+    LLM_API_KEYS_CREATE: '/admin/llm-api-keys',
+    LLM_API_KEYS_UPDATE: (id: string | number) => `/admin/llm-api-keys/${id}`,
+    LLM_API_KEYS_DELETE: (id: string | number) => `/admin/llm-api-keys/${id}`,
+    LLM_API_KEYS_TOGGLE_STATUS: (id: string | number) => `/admin/llm-api-keys/${id}/toggle-status`,
+
+    // LLM API Key-Model Relations
+    LLM_API_KEY_MODELS: '/admin/llm-api-key-models',
+    LLM_API_KEY_MODELS_LIST: (query?: string) => (query ? `/admin/llm-api-key-models?${query}` : '/admin/llm-api-key-models'),
+    LLM_API_KEY_MODELS_CREATE: '/admin/llm-api-key-models',
+    LLM_API_KEY_MODELS_UPDATE: (id: string | number) => `/admin/llm-api-key-models/${id}`,
+    LLM_API_KEY_MODELS_DELETE: (id: string | number) => `/admin/llm-api-key-models/${id}`,
+
     // ======================= CLASS BASED ROUTES ========================
     CLASS_BASED: '/class-based',
     CLASS_BASED_ID: (classId: string | number) => `/class-based/${classId}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM API Keys management interface for admins to create, edit, and delete API keys with provider selection, key types, status tracking, and daily usage limits.
  * Added LLM API Key-Model Relations management enabling admins to link API keys to models and configure per-minute and per-day request rate limits.
  * Enhanced admin sidebar navigation with shortcuts to the new management interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->