### PR TITLE
refactor(reference):Add similarity-based colors and score badges

### DIFF
--- a/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
@@ -44,34 +44,34 @@ interface IReturnItemQuery {
 const getSimilarityStyles = (s?: number) => {
     if (s == null) {
         return {
-            card: 'border-slate-200 bg-slate-50/70 dark:border-slate-700/70 dark:bg-slate-900/40',
+            card: 'border-slate-200 bg-slate-100/70 dark:border-slate-700/70 dark:bg-slate-900/40',
             badge: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
         };
     }
 
     if (s < 0.4) {
         return {
-            card: 'border-rose-200 bg-rose-50/80 dark:border-rose-900/60 dark:bg-rose-950/40',
+            card: 'border-rose-200 bg-rose-300/50 dark:border-rose-900/60 dark:bg-rose-800/20',
             badge: 'bg-rose-500/10 text-rose-700 border border-rose-200/70 dark:bg-rose-500/20 dark:text-rose-200 dark:border-rose-700/70',
         };
     }
 
     if (s >= 0.4 && s <= 0.5) {
         return {
-            card: 'border-amber-200 bg-amber-50/80 dark:border-amber-900/50 dark:bg-amber-950/40',
+            card: 'border-amber-200 bg-amber-100/70 dark:border-amber-900/50 dark:bg-amber-950/30',
             badge: 'bg-amber-500/10 text-amber-700 border border-amber-200/70 dark:bg-amber-500/20 dark:text-amber-200 dark:border-amber-700/70',
         };
     }
 
     if (s > 0.5 && s <= 0.65) {
         return {
-            card: 'border-sky-200 bg-sky-50/80 dark:border-sky-900/60 dark:bg-sky-950/40',
+            card: 'border-sky-200 bg-sky-200/50 dark:border-sky-900/60 dark:bg-sky-950/40',
             badge: 'bg-sky-500/10 text-sky-700 border border-sky-200/70 dark:bg-sky-500/20 dark:text-sky-200 dark:border-sky-700/70',
         };
     }
 
     return {
-        card: 'border-emerald-200 bg-emerald-50/80 dark:border-emerald-900/60 dark:bg-emerald-950/40',
+        card: 'border-emerald-200 bg-emerald-100/70 dark:border-emerald-900/60 dark:bg-emerald-950/30',
         badge: 'bg-emerald-500/10 text-emerald-700 border border-emerald-200/70 dark:bg-emerald-500/20 dark:text-emerald-200 dark:border-emerald-700/70',
     };
 };
@@ -331,10 +331,7 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
                 <div className={`rounded-lg p-4 transition-colors ${similarityStyles.card}`}>
                     <div className="">
                         <div className="flex-shrink-0">
-                            <p
-                                className="text-sm text-slate-900 dark:text-slate-50 leading-relaxed cursor-pointer hover:opacity-80"
-                                onClick={handleReferenceOriginContent}
-                            >
+                            <p className="text-sm text-slate-900 dark:text-slate-50 leading-relaxed hover:opacity-80">
                                 {displayText}
                             </p>
                         </div>
@@ -391,10 +388,7 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
                             </svg>
                         </div>
                         <div className="flex-1">
-                            <p
-                                className="text-sm text-slate-900 dark:text-slate-50 leading-relaxed cursor-pointer hover:opacity-80"
-                                onClick={handleReferenceOriginContent}
-                            >
+                            <p className="text-sm text-slate-900 dark:text-slate-50 leading-relaxed hover:opacity-80">
                                 {displayText}
                             </p>
 
@@ -495,7 +489,7 @@ function FileReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps) {
                     >
                         {pageNumber > 0 && (
                             <span
-                                className="text-[14px] px-3 py-1.5 rounded-full bg-slate-900/5 text-slate-700 dark:bg-slate-50/10 dark:text-slate-100 font-medium"
+                                className="text-sm px-3 py-1.5 rounded-full bg-slate-900/5 text-slate-700 dark:bg-slate-50/10 dark:text-slate-100 font-medium"
                                 title={t('pageNumberTitle')}
                             >
                                 {t('page', { pageNumber })}

--- a/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
@@ -398,7 +398,7 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
                                 {displayText}
                             </p>
 
-                            {rawContent.length > 240 && (
+                            {rawContent.length > defaultLengthConcat && (
                                 <div className="mt-2">
                                     <button
                                         onClick={() => setExpanded((e) => !e)}

--- a/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
@@ -328,38 +328,25 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
     if (!isShowMore) {
         return (
             <div className="px-2 relative">
-                {/* similarity score badge */}
-                <div className="absolute right-0 -top-2 translate-y-[-50%]">
-                    <span className={`text-[10px] px-2 py-0.5 rounded-full shadow-sm ${similarityStyles.badge}`}>
-                        sim {similarity?.toFixed(2) ?? '--'}
-                    </span>
-                </div>
-
-                <div
-                    className={`rounded-lg p-4 transition-colors ${similarityStyles.card}`}
-                    // keep icon & text colors modern but readable
-                >
-                    <div className="flex gap-3">
+                <div className={`rounded-lg p-4 transition-colors ${similarityStyles.card}`}>
+                    <div className="">
                         <div className="flex-shrink-0">
-                            <svg
-                                className="w-5 h-5 text-sky-600 dark:text-sky-400"
-                                fill="currentColor"
-                                viewBox="0 0 20 20"
-                            >
-                                <path
-                                    fillRule="evenodd"
-                                    d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                                    clipRule="evenodd"
-                                />
-                            </svg>
-                        </div>
-                        <div className="flex-1">
                             <p
                                 className="text-sm text-slate-900 dark:text-slate-50 leading-relaxed cursor-pointer hover:opacity-80"
                                 onClick={handleReferenceOriginContent}
                             >
                                 {displayText}
                             </p>
+                        </div>
+
+                        <div className="flex-1">
+                            <div className="">
+                                <span
+                                    className={`text-[10px] px-2 py-0.5 rounded-full shadow-sm ${similarityStyles.badge}`}
+                                >
+                                    similarity: {similarity?.toFixed(2) ?? '--'}
+                                </span>
+                            </div>
                             {timestamp && (
                                 <span
                                     className="inline-block mt-2 text-xs px-2 py-1 rounded bg-sky-100/80 dark:bg-sky-900/60 text-sky-800 dark:text-sky-200 cursor-pointer hover:bg-sky-200/90 dark:hover:bg-sky-800/80"

--- a/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
@@ -464,25 +464,27 @@ function FileReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps) {
 
     if (!isShowMore) {
         return (
-            <div className="text-center relative">
-                <div className="absolute right-0 -top-2 translate-y-[-20%">
-                    <span className={`text-[10px] px-2 py-0.5 rounded-full shadow-sm ${similarityStyles.badge}`}>
-                        similarity: {similarity?.toFixed(2) ?? '--'}
-                    </span>
-                </div>
-                <div
-                    className={`flex flex-col items-center gap-3 cursor-pointer hover:opacity-80 rounded-lg px-4 py-3 transition-colors ${similarityStyles.card}`}
+            <div>
+                <button
+                    type="button"
                     onClick={handleReferenceOriginContent}
+                    className={`relative inline-flex flex-col items-center justify-center rounded-xl px-5 py-3 shadow-sm transition-all duration-150 hover:shadow-md hover:-translate-y-[1px] ${similarityStyles.card}`}
                 >
                     {pageNumber > 0 && (
                         <span
-                            className={`text-[14px] px-3 py-1.5 rounded-full font-medium ${similarityStyles.card}`}
+                            className="mt-1 text-sm md:text-[15px] font-semibold text-slate-50 tracking-tight"
                             title={t('pageNumberTitle')}
                         >
                             {t('page', { pageNumber })}
                         </span>
                     )}
-                </div>
+
+                    <span
+                        className={`mt-5 px-3 py-0.5 text-[11px] leading-none rounded-full shadow-sm border ${similarityStyles.badge}`}
+                    >
+                        similarity: {similarity?.toFixed(2) ?? '--'}
+                    </span>
+                </button>
             </div>
         );
     }

--- a/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/reference/Reference.tsx
@@ -41,6 +41,41 @@ interface IReturnItemQuery {
     similarity: number;
 }
 
+const getSimilarityStyles = (s?: number) => {
+    if (s == null) {
+        return {
+            card: 'border-slate-200 bg-slate-50/70 dark:border-slate-700/70 dark:bg-slate-900/40',
+            badge: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
+        };
+    }
+
+    if (s < 0.4) {
+        return {
+            card: 'border-rose-200 bg-rose-50/80 dark:border-rose-900/60 dark:bg-rose-950/40',
+            badge: 'bg-rose-500/10 text-rose-700 border border-rose-200/70 dark:bg-rose-500/20 dark:text-rose-200 dark:border-rose-700/70',
+        };
+    }
+
+    if (s >= 0.4 && s <= 0.5) {
+        return {
+            card: 'border-amber-200 bg-amber-50/80 dark:border-amber-900/50 dark:bg-amber-950/40',
+            badge: 'bg-amber-500/10 text-amber-700 border border-amber-200/70 dark:bg-amber-500/20 dark:text-amber-200 dark:border-amber-700/70',
+        };
+    }
+
+    if (s > 0.5 && s <= 0.65) {
+        return {
+            card: 'border-sky-200 bg-sky-50/80 dark:border-sky-900/60 dark:bg-sky-950/40',
+            badge: 'bg-sky-500/10 text-sky-700 border border-sky-200/70 dark:bg-sky-500/20 dark:text-sky-200 dark:border-sky-700/70',
+        };
+    }
+
+    return {
+        card: 'border-emerald-200 bg-emerald-50/80 dark:border-emerald-900/60 dark:bg-emerald-950/40',
+        badge: 'bg-emerald-500/10 text-emerald-700 border border-emerald-200/70 dark:bg-emerald-500/20 dark:text-emerald-200 dark:border-emerald-700/70',
+    };
+};
+
 export default function Reference({ content, triggerClassName = '', className, children }: IProps) {
     const t = useTranslations('topic.reference');
     const { learningMaterial } = useTopicWorkspace();
@@ -261,12 +296,17 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
     const { seekTo } = useTopicWorkspace();
     const [expanded, setExpanded] = useState(false);
 
+    const { similarity } = safeDestructure(item);
+
+    const similarityStyles = getSimilarityStyles(similarity);
+
     const rawContent =
         typeof item.originContent?.content === 'string'
             ? item.originContent.content
             : JSON.stringify(item.originContent?.content);
 
-    const defaultLengthConcat = 240;
+    const defaultLengthConcat = 100;
+
     const displayText = expanded ? rawContent : truncate(rawContent, defaultLengthConcat);
 
     const { startTime } = safeDestructure(item?.metadata as MetaDataYoutubeContent, {
@@ -287,12 +327,22 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
 
     if (!isShowMore) {
         return (
-            <div className="px-2">
-                <div className="rounded-lg border border-blue-200 bg-blue-50 dark:bg-blue-950/30 dark:border-blue-800 p-4">
+            <div className="px-2 relative">
+                {/* similarity score badge */}
+                <div className="absolute right-0 -top-2 translate-y-[-50%]">
+                    <span className={`text-[10px] px-2 py-0.5 rounded-full shadow-sm ${similarityStyles.badge}`}>
+                        sim {similarity?.toFixed(2) ?? '--'}
+                    </span>
+                </div>
+
+                <div
+                    className={`rounded-lg p-4 transition-colors ${similarityStyles.card}`}
+                    // keep icon & text colors modern but readable
+                >
                     <div className="flex gap-3">
                         <div className="flex-shrink-0">
                             <svg
-                                className="w-5 h-5 text-blue-600 dark:text-blue-400"
+                                className="w-5 h-5 text-sky-600 dark:text-sky-400"
                                 fill="currentColor"
                                 viewBox="0 0 20 20"
                             >
@@ -305,14 +355,14 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
                         </div>
                         <div className="flex-1">
                             <p
-                                className="text-sm text-blue-800 dark:text-blue-200 leading-relaxed cursor-pointer hover:opacity-70"
+                                className="text-sm text-slate-900 dark:text-slate-50 leading-relaxed cursor-pointer hover:opacity-80"
                                 onClick={handleReferenceOriginContent}
                             >
                                 {displayText}
                             </p>
                             {timestamp && (
                                 <span
-                                    className="inline-block mt-2 text-xs px-2 py-1 rounded bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 cursor-pointer hover:bg-blue-200 dark:hover:bg-blue-800"
+                                    className="inline-block mt-2 text-xs px-2 py-1 rounded bg-sky-100/80 dark:bg-sky-900/60 text-sky-800 dark:text-sky-200 cursor-pointer hover:bg-sky-200/90 dark:hover:bg-sky-800/80"
                                     title={t('startTime')}
                                     onClick={handleReferenceOriginContent}
                                 >
@@ -327,13 +377,22 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
     }
 
     return (
-        <div className="relative rounded-xl border border-border bg-card text-card-foreground p-5 md:p-6 shadow-sm">
+        <div
+            className={`relative rounded-xl border bg-card text-card-foreground p-5 md:p-6 shadow-sm transition-colors ${similarityStyles.card}`}
+        >
+            {/* similarity score badge */}
+            <div className="absolute right-4 top-3">
+                <span className={`text-[11px] px-2.5 py-0.5 rounded-full shadow-sm ${similarityStyles.badge}`}>
+                    similarity: {similarity?.toFixed(2) ?? '--'}
+                </span>
+            </div>
+
             <div className="px-2">
-                <div className="rounded-lg border border-blue-200 bg-blue-50 dark:bg-blue-950/30 dark:border-blue-800 p-4">
+                <div className="rounded-lg p-4 border border-transparent/0">
                     <div className="flex gap-3">
                         <div className="flex-shrink-0">
                             <svg
-                                className="w-5 h-5 text-blue-600 dark:text-blue-400"
+                                className="w-5 h-5 text-sky-600 dark:text-sky-400"
                                 fill="currentColor"
                                 viewBox="0 0 20 20"
                             >
@@ -346,7 +405,7 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
                         </div>
                         <div className="flex-1">
                             <p
-                                className="text-sm text-blue-800 dark:text-blue-200 leading-relaxed cursor-pointer hover:opacity-70"
+                                className="text-sm text-slate-900 dark:text-slate-50 leading-relaxed cursor-pointer hover:opacity-80"
                                 onClick={handleReferenceOriginContent}
                             >
                                 {displayText}
@@ -356,7 +415,7 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
                                 <div className="mt-2">
                                     <button
                                         onClick={() => setExpanded((e) => !e)}
-                                        className="text-xs underline decoration-dotted text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+                                        className="text-xs underline decoration-dotted text-sky-700 dark:text-sky-300 hover:text-sky-800 dark:hover:text-sky-200"
                                     >
                                         {expanded ? t('showLess') : t('showMore')}
                                     </button>
@@ -365,7 +424,7 @@ function YouTubeReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps)
 
                             {timestamp && (
                                 <span
-                                    className="inline-block mt-2 text-xs px-2 py-1 rounded bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 cursor-pointer hover:bg-blue-200 dark:hover:bg-blue-800"
+                                    className="inline-block mt-2 text-xs px-2 py-1 rounded bg-sky-100/80 dark:bg-sky-900/60 text-sky-800 dark:text-sky-200 cursor-pointer hover:bg-sky-200/90 dark:hover:bg-sky-800/80"
                                     title={t('startTime')}
                                     onClick={handleReferenceOriginContent}
                                 >
@@ -384,6 +443,10 @@ function FileReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps) {
     const t = useTranslations('topic.reference');
     const { setPageNumber } = useTopicWorkspace();
 
+    const { similarity } = safeDestructure(item);
+
+    const similarityStyles = getSimilarityStyles(similarity);
+
     const { pageNumber } = safeDestructure(item?.metadata as MetaDataFileContent, {
         pageNumber: -1,
     });
@@ -401,14 +464,19 @@ function FileReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps) {
 
     if (!isShowMore) {
         return (
-            <div className="text-center">
+            <div className="text-center relative">
+                <div className="absolute right-0 -top-2 translate-y-[-20%">
+                    <span className={`text-[10px] px-2 py-0.5 rounded-full shadow-sm ${similarityStyles.badge}`}>
+                        similarity: {similarity?.toFixed(2) ?? '--'}
+                    </span>
+                </div>
                 <div
-                    className="flex flex-col items-center gap-3 cursor-pointer hover:opacity-65"
+                    className={`flex flex-col items-center gap-3 cursor-pointer hover:opacity-80 rounded-lg px-4 py-3 transition-colors ${similarityStyles.card}`}
                     onClick={handleReferenceOriginContent}
                 >
                     {pageNumber > 0 && (
                         <span
-                            className="text-[14px] px-3 py-1.5 rounded-full bg-secondary text-muted-foreground font-medium hover:bg-opacity-70"
+                            className={`text-[14px] px-3 py-1.5 rounded-full font-medium ${similarityStyles.card}`}
                             title={t('pageNumberTitle')}
                         >
                             {t('page', { pageNumber })}
@@ -420,16 +488,25 @@ function FileReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps) {
     }
 
     return (
-        <div className="relative rounded-xl border border-border bg-card text-card-foreground p-5 md:p-6 shadow-sm">
+        <div
+            className={`relative rounded-xl border bg-card text-card-foreground p-5 md:p-6 shadow-sm transition-colors ${similarityStyles.card}`}
+        >
+            {/* similarity badge */}
+            <div className="absolute right-4 top-3">
+                <span className={`text-[11px] px-2.5 py-0.5 rounded-full shadow-sm ${similarityStyles.badge}`}>
+                    similarity {similarity?.toFixed(2) ?? '--'}
+                </span>
+            </div>
+
             <div className="px-2">
                 <div className="text-center">
                     <div
-                        className="flex flex-col items-center gap-3 cursor-pointer hover:opacity-65"
+                        className="flex flex-col items-center gap-3 cursor-pointer hover:opacity-80"
                         onClick={handleReferenceOriginContent}
                     >
                         {pageNumber > 0 && (
                             <span
-                                className="text-[14px] px-3 py-1.5 rounded-full bg-secondary text-muted-foreground font-medium hover:bg-slate-600"
+                                className="text-[14px] px-3 py-1.5 rounded-full bg-slate-900/5 text-slate-700 dark:bg-slate-50/10 dark:text-slate-100 font-medium"
                                 title={t('pageNumberTitle')}
                             >
                                 {t('page', { pageNumber })}
@@ -441,7 +518,7 @@ function FileReferenceItem({ item, isShowMore, onClose }: ReferenceItemProps) {
 
             <div className="mt-4 flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                    <span className="text-[10px] px-2 py-1 rounded bg-muted border border-border text-muted-foreground">
+                    <span className="text-[10px] px-2 py-1 rounded bg-slate-900/5 border border-border text-muted-foreground">
                         {item.contentType}
                     </span>
                 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reference items now show similarity indicators as color-coded badges (visible in both collapsed and expanded views) to highlight relevance levels.

* **Style**
  * Updated reference card styling and theming (badge, timestamp, icons, and text colors) for clearer visual hierarchy.
  * Improved badge positioning and layout to prevent shifts and a shorter collapsed preview length for reference content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->