### PR TITLE
fix(generate): loading save content topic after generate

### DIFF
--- a/src/app/[locale]/generate/components/CardImport.tsx
+++ b/src/app/[locale]/generate/components/CardImport.tsx
@@ -26,7 +26,7 @@ import { MODE_ACCESS_PAGE_ROLE } from '@/utils/constants/common.constant';
 
 interface CardImportProps {
     onOpenChange?: (open: boolean) => void;
-    onComplete?: (data: any) => void;
+    onComplete?: (data: unknown) => void;
     classProps: ClassPropsInGenerate;
 }
 
@@ -36,7 +36,7 @@ const CardImport: React.FC<CardImportProps> = ({ onComplete = () => {}, classPro
     const tFileTab = useTranslations('generate.fileTab');
 
     const { textContent, extractedContent, activeTab } = useCardImportSelector((state) => state.contentExtraction);
-    const { step, importMethod, files, selectedMethod, isProcessing, isUploading } = useCardImportSelector(
+    const { step, importMethod, files, selectedMethod, isProcessing } = useCardImportSelector(
         (state) => state.importDialog,
     );
 

--- a/src/app/[locale]/generate/components/CardImport.tsx
+++ b/src/app/[locale]/generate/components/CardImport.tsx
@@ -253,12 +253,6 @@ const CardImport: React.FC<CardImportProps> = ({ onComplete = () => {}, classPro
                     </Button>
                 </CardFooter>
             </Card>
-            {isUploading && (
-                <LoadingOverlay
-                    title={tFileTab('loading.uploading.title')}
-                    description={tFileTab('loading.uploading.description')}
-                />
-            )}
         </Fragment>
     );
 };

--- a/src/app/[locale]/generate/components/ContentGenerationPreview.tsx
+++ b/src/app/[locale]/generate/components/ContentGenerationPreview.tsx
@@ -10,6 +10,8 @@ import { CreateTopicModal } from '../../topics/components/modals/CreateTopicModa
 import { ICreateTopicPayload } from '@/services/topic/topic.service';
 import { ICreateClassFeedBody } from '@/services/class-based-learning/classFeed.service';
 import CreateFeedModal, { IDefaultFeed } from '../../teacher/feeds/components/modals/CreateFeedModal';
+import { useCardImportSelector } from '../hooks/useReduxStore';
+import { safeDestructure } from '@/utils';
 
 export type ContentType = 'flashcard' | 'quiz' | 'mindmap';
 
@@ -53,7 +55,7 @@ interface GenerateContentForNodeProps extends BaseContentGenerationProps {
 
 const ContentGenerationPreview: React.FC<ContentGenerationPreviewProps> = (props) => {
     const { shouldCreateTopic, sseData, dataGenerated, setDataGenerated, onSave } = props;
-
+    const { isUploading } = safeDestructure(useCardImportSelector((state) => state.importDialog));
     // Determine content type based on sseData or other criteria
     const getContentType = (): ContentType | null => {
         return detectContentType(sseData);
@@ -82,6 +84,7 @@ const ContentGenerationPreview: React.FC<ContentGenerationPreviewProps> = (props
                         isOpen={props.isTopicModalOpen}
                         setIsOpen={props.setIsTopicModalOpen}
                         onSubmit={onSave}
+                        loading={isUploading}
                     />
                     {props.shouldCreateFeed === true &&
                     props.isFeedModalOpen &&

--- a/src/app/[locale]/generate/hooks/useContentGeneration.ts
+++ b/src/app/[locale]/generate/hooks/useContentGeneration.ts
@@ -166,8 +166,6 @@ export const useContentGeneration = ({
 
     const handleInsertResourceContent = async (topicId: string | number | undefined): Promise<boolean> => {
         try {
-            dispatch(startUploading());
-
             if (isNilOrEmpty(topicId as string)) {
                 toast({
                     description: tCommon('labels.noContent'),
@@ -220,6 +218,7 @@ export const useContentGeneration = ({
                             ...fileInfo,
                         },
                     });
+
                     break;
                 case RESOURCE_CONTENT_TYPE.YOUTUBE: {
                     const youtubePayload: YoutubeResourcePayload = {
@@ -269,8 +268,6 @@ export const useContentGeneration = ({
                 description: tCommon('messages.createError'),
             });
             return false;
-        } finally {
-            dispatch(stopUploading());
         }
     };
 
@@ -284,6 +281,8 @@ export const useContentGeneration = ({
                 });
                 return;
             }
+
+            dispatch(startUploading());
 
             let result;
 
@@ -316,6 +315,9 @@ export const useContentGeneration = ({
                 });
                 return;
             }
+            toast({
+                description: 'Content Topic Saved',
+            });
 
             const topicId = result?.topicId;
 
@@ -355,6 +357,8 @@ export const useContentGeneration = ({
                 description: tCommon('messages.createError'),
                 variant: 'destructive',
             });
+        } finally {
+            dispatch(stopUploading());
         }
     };
 

--- a/src/app/[locale]/home/components/CurrentProcessLearning.tsx
+++ b/src/app/[locale]/home/components/CurrentProcessLearning.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useRouter } from 'next/navigation';
 import { toast } from '@/hooks/use-toast';
 import { ROUTES } from '@/utils/constants/routes';
+import { METHOD_LEARNING } from '../../generate/constants/resource';
 
 interface CurrentLearning {
     topicName?: string;
@@ -86,11 +87,20 @@ const CurrentProcessLearning: React.FC<CurrentProcessLearningProps> = ({}) => {
             return;
         }
 
+        let tab = null;
+
         if (currentLearning.type === 'flashcard') {
-            router.push(ROUTES.FLASHCARDS_LEARNING(topicId));
+            tab = METHOD_LEARNING.FLASHCARD;
         } else if (currentLearning.type === 'question') {
-            router.push(ROUTES.QUIZ_START(topicId));
+            tab = METHOD_LEARNING.QUIZ;
         }
+
+        router.push(
+            ROUTES.TOPIC_WORKSPACE({
+                topicId,
+                tab,
+            }),
+        );
     };
 
     if (loading) {

--- a/src/app/[locale]/topics/components/common/TopicCard.tsx
+++ b/src/app/[locale]/topics/components/common/TopicCard.tsx
@@ -7,7 +7,6 @@ import { DropdownMenu, DropdownMenuTrigger } from '@/components/ui/dropdown-menu
 import { ITopic } from '../../types/topic.type';
 
 import { motion, useMotionTemplate, useMotionValue } from 'framer-motion';
-import { useTranslations } from 'next-intl';
 
 interface Props {
     topic: ITopic;

--- a/src/app/[locale]/topics/components/modals/CreateTopicModal.tsx
+++ b/src/app/[locale]/topics/components/modals/CreateTopicModal.tsx
@@ -1,3 +1,4 @@
+import LoadingPage from '@/app/loading';
 import { Modal } from '@/components/modal/Modal';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -66,6 +67,8 @@ export function CreateTopicModal({ isOpen, setIsOpen, onSubmit, loading }: Props
             title={tCommon('titles.createNew', { name: tTopic('topic') })}
             body={
                 <div className="flex flex-col gap-4">
+                    {loading && <LoadingPage isOverlay={true} size={100} />}
+
                     <div className="flex flex-col gap-2">
                         <div className="text-primary text-base font-normal">{tCommon('labels.name')}</div>
                         <Input value={name} onChange={handleNameChange} />

--- a/src/app/[locale]/topics/components/ui/PersonalTopicLibrary.tsx
+++ b/src/app/[locale]/topics/components/ui/PersonalTopicLibrary.tsx
@@ -231,7 +231,7 @@ export default function PersonalTopicLibrary() {
         const totalFlashcards = topic.flashcardCounts?.total || 0;
         const learningFlashcards = topic.flashcardCounts?.learning || 0;
         const dueTodayFlashcards = topic.flashcardCounts?.review || 0;
-        
+
         function handleOnSelectLearning() {
             router.push(ROUTES.FLASHCARDS_LEARNING(topicId));
         }
@@ -262,16 +262,6 @@ export default function PersonalTopicLibrary() {
                         />
                         <div className="absolute inset-0 animate-[shimmer_2.5s_infinite] bg-[linear-gradient(110deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.5)_40%,rgba(255,255,255,0)_80%)] dark:bg-[linear-gradient(110deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.15)_40%,rgba(255,255,255,0)_80%)] bg-[length:200%_100%]" />
                     </div>
-                </div>
-                <div className="flex items-center justify-between gap-3">
-                    <Button
-                        size="sm"
-                        variant="secondary"
-                        className="h-7 px-3 rounded-full bg-slate-900/5 dark:bg-slate-800/80 hover:bg-slate-900/10 dark:hover:bg-slate-700/70 text-[0.65rem] font-medium tracking-wide border border-slate-300/60 dark:border-transparent backdrop-blur-sm"
-                        onClick={handleOnSelectLearning}
-                    >
-                        {tTopic('learning')}
-                    </Button>
                 </div>
             </div>
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a redundant loading overlay during imports so no overlay appears during file uploads.
  * Removed per-item learning button from topic cards to avoid dead/unused actions.

* **New Features**
  * Added "Content Topic Saved" notifications after successful topic creation or resource attachment.
  * Consolidated learning navigation to open the topic workspace with an appropriate tab.

* **Refactor**
  * Uploading state now reflects only top-level save operations and loading is propagated to modals.

* **Style**
  * Removed an unused import to clean up code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->