### PR TITLE
fix(generate): reset init state when convert file fail

### DIFF
--- a/src/app/[locale]/generate/components/import/components/FileTab.tsx
+++ b/src/app/[locale]/generate/components/import/components/FileTab.tsx
@@ -4,7 +4,7 @@ import React, { memo, useCallback, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { Upload } from 'lucide-react';
-import { setFiles } from '@/app/[locale]/generate/stores/features/importDialogSlice';
+import { resetImportDialog, setFiles } from '@/app/[locale]/generate/stores/features/importDialogSlice';
 import { toast } from '@/hooks/use-toast';
 import {
     ALLOWED_FILE_TYPES,
@@ -68,6 +68,7 @@ const FileTab: React.FC = () => {
                 const arrayBuffer = await upload(file);
 
                 if (!arrayBuffer) {
+                    dispatch(resetImportDialog());
                     toast({
                         description: t('toasts.convertFailed'),
                     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during file import by properly resetting the import dialog state when conversion fails, providing better recovery when reprocessing files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->