### PR TITLE
feat(mindmap): separate button for roadmap

### DIFF
--- a/src/app/[locale]/mindmap/[topicId]/page.tsx
+++ b/src/app/[locale]/mindmap/[topicId]/page.tsx
@@ -36,6 +36,7 @@ import { useTheme } from 'next-themes';
 import { useSetCenterOnRoot } from '../hooks/useSetCenterOnRoot';
 
 import MindmapButtonsPanel from '../components/MindmapButtonsPanel';
+import RoadmapButtonPanel from '../components/RoadmapButtonPanel';
 
 const defaultEdgeOptions = {
     type: 'floating',
@@ -231,6 +232,7 @@ export default function page() {
                 </Panel> */}
 
                 <MindmapButtonsPanel />
+                <RoadmapButtonPanel />
                 <FileSheet />
                 <NodeSheet />
                 <Controls />

--- a/src/app/[locale]/mindmap/components/CustomReactFlowNode.tsx
+++ b/src/app/[locale]/mindmap/components/CustomReactFlowNode.tsx
@@ -9,7 +9,7 @@ import { openSheet, setSelectedNodeData, toggleNodeSelection } from '@/stores/fe
 import { getRouter } from '@/utils/routerService';
 import CommentThread from '../../class-based/components/comment/CommentThread';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Edit2, Save, X, BookOpenIcon, FileText, Target, MessageCircle, Plus, CheckCircle } from 'lucide-react';
+import { Edit2, Save, X, BookOpenIcon, FileText, Target, MessageCircle, Plus, CheckCircle, MoreHorizontal } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 import { Progress } from '@/components/ui/progress';
 import { useTranslations } from 'next-intl';
@@ -118,6 +118,11 @@ const CustomReactFlowNode = ({ data }: { data: CustomNodeData }) => {
         dispatch(openSheet());
     };
 
+    const handleGhostIconClick = (e: React.MouseEvent) => {
+        e.stopPropagation(); // Prevent triggering handleClickNode
+        handleRightClickNode(e as any);
+    };
+
     const handleKeyPress = (e: React.KeyboardEvent) => {
         if (e.key === 'Enter') {
             handleSave(label);
@@ -212,6 +217,23 @@ const CustomReactFlowNode = ({ data }: { data: CustomNodeData }) => {
                 } as React.CSSProperties
             }
         >
+            {/* GHOST ICON: Only visible on hover, triggers the "Right Click" menu */}
+            {!isEditingMindmap && !isMultiSelectMode && (
+                <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: isHovered ? 1 : 0 }}
+                    className="absolute top-2 right-2 z-30"
+                >
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 rounded-md hover:bg-muted bg-card/50 backdrop-blur-sm border shadow-sm"
+                        onClick={handleGhostIconClick}
+                    >
+                        <MoreHorizontal className="w-4 h-4 text-muted-foreground" />
+                    </Button>
+                </motion.div>
+            )}
             {/* Completed Indicator Tick */}
             {isComplete && (
                 <motion.div

--- a/src/app/[locale]/mindmap/components/MindmapButtonsPanel.tsx
+++ b/src/app/[locale]/mindmap/components/MindmapButtonsPanel.tsx
@@ -76,18 +76,8 @@ const MindmapButtonsPanel = ({ mode, role = UserRoleEnum.TEACHER }: Props) => {
                     ''
                 )}
 
-                {/* <Separator className="my-4" /> */}
-
-                <RoadmapButton
-                    isPanelExpanded={isPanelExpanded}
-                    nodes={nodes}
-                    edges={edges}
-                    setNodes={setNodes}
-                    role={role}
-                    mode={mode}
-                />
+ 
                 <DownloadButton />
-                {/* <ImportMindmapButton isPanelExpanded={isPanelExpanded} /> */}
                 {mode === MODE_ACCESS_PAGE_ROLE.personal || role === UserRoleEnum.TEACHER ? (
                     <>
                         <ImportButton isPanelExpanded={isPanelExpanded} />

--- a/src/app/[locale]/mindmap/components/RoadmapButtonPanel.tsx
+++ b/src/app/[locale]/mindmap/components/RoadmapButtonPanel.tsx
@@ -1,0 +1,40 @@
+import { Panel } from '@xyflow/react';
+import React, { useState } from 'react';
+
+import { useMindMapContext } from '../context/MindMapContext';
+
+import RoadmapButton from './buttons/RoadmapButton';
+import { UserRoleEnum } from '@/utils/constants/roles';
+import { ILearningMode } from '@/stores/features/class-based-learning/learningModeSlice';
+
+interface StudentProps {
+    role: UserRoleEnum.USER;
+}
+interface TeacherProps {
+    role?: UserRoleEnum.TEACHER;
+}
+
+type Props = { mode?: ILearningMode } & (StudentProps | TeacherProps);
+
+const RoadmapButtonPanel = ({ mode, role = UserRoleEnum.TEACHER }: Props) => {
+    const [isPanelExpanded] = useState(false);
+
+    const { nodes, edges, setNodes } = useMindMapContext();
+
+    return (
+        <Panel position="top-right">
+            <div className="flex gap-2 flex-row">
+                <RoadmapButton
+                    isPanelExpanded={isPanelExpanded}
+                    nodes={nodes}
+                    edges={edges}
+                    setNodes={setNodes}
+                    role={role}
+                    mode={mode}
+                />
+            </div>
+        </Panel>
+    );
+};
+
+export default RoadmapButtonPanel;

--- a/src/app/[locale]/mindmap/components/buttons/RoadmapButton.tsx
+++ b/src/app/[locale]/mindmap/components/buttons/RoadmapButton.tsx
@@ -6,7 +6,6 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/co
 
 import { AppEdge, AppNode } from '@/types/mindmap/mindmap.type';
 import RoadmapList from '../RoadmapList';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { UserRoleEnum } from '@/utils/constants/roles';
 import { ILearningMode } from '@/stores/features/class-based-learning/learningModeSlice';
 
@@ -81,16 +80,13 @@ const RoadmapButton = ({ isPanelExpanded, nodes, edges, setNodes, role, mode }: 
 
     return (
         <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <SheetTrigger asChild>
-                        <Button size="icon-sm" variant="outline">
-                            <Signpost />
-                        </Button>
-                    </SheetTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{t('RoadmapButtonLabel')}</TooltipContent>
-            </Tooltip>
+            <SheetTrigger asChild>
+                <Button variant="outline">
+                    <Signpost />
+                    Roadmap
+                </Button>
+            </SheetTrigger>
+
             <SheetContent>
                 <SheetHeader>
                     <SheetTitle>{t('RoadmapButtonLabel')}</SheetTitle>

--- a/src/app/[locale]/topics/[topicId]/(topic)/components/mindmap/MindmapContent.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/mindmap/MindmapContent.tsx
@@ -19,7 +19,12 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/componen
 import NodeFlashcardsBrowse from '../flashcard/node/NodeFlashcardsBrowse';
 import { useAppSelector } from '@/stores/hooks';
 import { useDispatch } from 'react-redux';
-import { clearNodeSelection, closeSheet, turnOffMultiSelectMode } from '@/stores/features/mindmap/selectedNodeSlice';
+import {
+    clearNodeSelection,
+    clearSelectedNodeData,
+    closeSheet,
+    turnOffMultiSelectMode,
+} from '@/stores/features/mindmap/selectedNodeSlice';
 import NodeFlashcardsEdit from '../flashcard/node/NodeFlashcardsEdit';
 import NodeFlashcardsLinker from '../flashcard/node/NodeFlashcardsLinker';
 import NodeFlashcardsLearning from '../flashcard/node/NodeFlashcardsLearning';
@@ -62,6 +67,7 @@ const MindmapContent = ({ mode, role }: Props) => {
         saveMindmap,
         hasInitialized,
         fitView,
+        setIsNodeSheetOpen,
     } = useTopicWorkspace();
 
     const [showGenerateModal, setShowGenerateModal] = useState(false);
@@ -186,6 +192,8 @@ const MindmapContent = ({ mode, role }: Props) => {
         return () => {
             dispatch(clearNodeSelection());
             dispatch(turnOffMultiSelectMode());
+            setIsNodeSheetOpen(false);
+            dispatch(clearSelectedNodeData());
         };
     }, []);
 

--- a/src/app/[locale]/topics/[topicId]/(topic)/components/mindmap/MindmapContent.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/mindmap/MindmapContent.tsx
@@ -29,6 +29,7 @@ import { IGenerateNodeFlashcardsItem } from '../../types/generate.type';
 import MultiNodeFlashcardsPreview from '../flashcard/node/MultiNodeFlashcardsPreview';
 import MultiNodeGeneratePanel from '../flashcard/node/MultiNodeGeneratePanel';
 import RoadmapButtonPanel from '@/app/[locale]/mindmap/components/RoadmapButtonPanel';
+import { useTopicWorkspace } from '../../context/TopicWorkspaceContext';
 
 //set react flow to use custom nodes & edges
 const nodeTypes = {
@@ -51,7 +52,6 @@ type FlashcardsViewMode = 'none' | 'browse' | 'edit' | 'link' | 'learning' | 'mu
 
 const MindmapContent = ({ mode, role }: Props) => {
     const {
-        topicId,
         isLoading,
         nodes,
         edges,
@@ -59,15 +59,10 @@ const MindmapContent = ({ mode, role }: Props) => {
         setEdges,
         onNodesChange,
         onEdgesChange,
-        isSaving,
         saveMindmap,
-        sseData,
-        sseStatus,
         hasInitialized,
-        isProcessingRegisterGenerate,
-        executeGenerate,
         fitView,
-    } = useMindMapContext();
+    } = useTopicWorkspace();
 
     const [showGenerateModal, setShowGenerateModal] = useState(false);
     const [hasShownModal, setHasShownModal] = useState(false);

--- a/src/app/[locale]/topics/[topicId]/(topic)/components/mindmap/MindmapContent.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/mindmap/MindmapContent.tsx
@@ -28,6 +28,7 @@ import { ILearningMode } from '@/stores/features/class-based-learning/learningMo
 import { IGenerateNodeFlashcardsItem } from '../../types/generate.type';
 import MultiNodeFlashcardsPreview from '../flashcard/node/MultiNodeFlashcardsPreview';
 import MultiNodeGeneratePanel from '../flashcard/node/MultiNodeGeneratePanel';
+import RoadmapButtonPanel from '@/app/[locale]/mindmap/components/RoadmapButtonPanel';
 
 //set react flow to use custom nodes & edges
 const nodeTypes = {
@@ -271,6 +272,7 @@ const MindmapContent = ({ mode, role }: Props) => {
                         className={showGenerateModal ? 'blur-sm' : ''}
                     >
                         <MindmapButtonsPanel mode={mode} role={role} />
+                        <RoadmapButtonPanel mode={mode} role={role} />
                         <MultiNodeGeneratePanel
                             nodes={nodes}
                             nodeIds={selectedNodeIds}

--- a/src/app/[locale]/topics/[topicId]/(topic)/components/tabs/MindMapTab.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/components/tabs/MindMapTab.tsx
@@ -38,8 +38,8 @@ export default function MindmapTab({}: Props) {
     if (isNil(learningFlashcards) || isNil(flashcards) || isNil(ankiSettings)) return <DataStatus variant="empty" />;
 
     return (
-        <MindMapProvider>
+        // <MindMapProvider>
             <MindmapContent mode={learningMode as ILearningMode} role={getRole()} />
-        </MindMapProvider>
+        // </MindMapProvider>
     );
 }

--- a/src/app/[locale]/topics/[topicId]/(topic)/context/TopicWorkspaceContext.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/context/TopicWorkspaceContext.tsx
@@ -30,6 +30,9 @@ import { YouTubePlayer } from 'react-youtube';
 import { INote } from '../types/note.type';
 import useNoteWorkspace from '../hooks/useNoteWorkspace';
 import { FlashcardTab } from '../components/flashcard/FlashcardContent';
+import { MindMapProvider, useMindMapContext } from '@/app/[locale]/mindmap/context/MindMapContext';
+import { AppEdge, AppNode } from '@/types/mindmap/mindmap.type';
+import { FitView } from '@xyflow/react';
 
 export type TypeTopicId = number;
 
@@ -89,6 +92,18 @@ interface ContextType {
 
     isLearningContentFullscreen: boolean;
     setIsLearningContentFullscreen: Dispatch<SetStateAction<boolean>>;
+
+    //mindmap
+    isLoading: boolean;
+    nodes: AppNode[];
+    edges: AppEdge[];
+    setNodes: (nodes: AppNode[] | ((nodes: AppNode[]) => AppNode[])) => void;
+    setEdges: (edges: AppEdge[] | ((edges: AppEdge[]) => AppEdge[])) => void;
+    onNodesChange: (changes: any) => void;
+    onEdgesChange: (changes: any) => void;
+    saveMindmap: () => Promise<void>;
+    hasInitialized: boolean;
+    fitView: FitView;
 }
 
 const TopicWorkspaceContext = createContext<ContextType | null>(null);
@@ -145,6 +160,19 @@ export function TopicWorkspaceProvider({ children, topicIdInit }: IProviderProps
         onCreateFlashcardsSuccess,
     } = useFlashCardWorkSpace({ topicId: topicIdRef.current, currentTab: tab });
 
+    const {
+        isLoading,
+        nodes,
+        edges,
+        setNodes,
+        setEdges,
+        onNodesChange,
+        onEdgesChange,
+        saveMindmap,
+        hasInitialized,
+        fitView,
+    } = useMindMapContext();
+
     const { selectedGame, selectGame, resetGame } = useGamesWorkSpace();
 
     const { note, setNote } = useNoteWorkspace();
@@ -198,6 +226,16 @@ export function TopicWorkspaceProvider({ children, topicIdInit }: IProviderProps
             onCreateFlashcardsSuccess,
             isLearningContentFullscreen,
             setIsLearningContentFullscreen,
+            isLoading,
+            nodes,
+            edges,
+            setNodes,
+            setEdges,
+            onNodesChange,
+            onEdgesChange,
+            saveMindmap,
+            hasInitialized,
+            fitView,
         }),
         [
             tab,
@@ -225,10 +263,24 @@ export function TopicWorkspaceProvider({ children, topicIdInit }: IProviderProps
             onBatchFlashcardsSuccess,
             onCreateFlashcardsSuccess,
             isLearningContentFullscreen,
+            isLoading,
+            nodes,
+            edges,
+            setNodes,
+            setEdges,
+            onNodesChange,
+            onEdgesChange,
+            saveMindmap,
+            hasInitialized,
+            fitView,
         ],
     );
 
-    return <TopicWorkspaceContext.Provider value={value}>{children}</TopicWorkspaceContext.Provider>;
+    return (
+        
+            <TopicWorkspaceContext.Provider value={value}>{children}</TopicWorkspaceContext.Provider>
+        
+    );
 }
 
 export function useTopicWorkspace() {

--- a/src/app/[locale]/topics/[topicId]/(topic)/context/TopicWorkspaceContext.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/context/TopicWorkspaceContext.tsx
@@ -104,6 +104,7 @@ interface ContextType {
     saveMindmap: () => Promise<void>;
     hasInitialized: boolean;
     fitView: FitView;
+    setIsNodeSheetOpen: (open: boolean) => void;
 }
 
 const TopicWorkspaceContext = createContext<ContextType | null>(null);
@@ -171,6 +172,7 @@ export function TopicWorkspaceProvider({ children, topicIdInit }: IProviderProps
         saveMindmap,
         hasInitialized,
         fitView,
+        setIsNodeSheetOpen,
     } = useMindMapContext();
 
     const { selectedGame, selectGame, resetGame } = useGamesWorkSpace();
@@ -236,6 +238,7 @@ export function TopicWorkspaceProvider({ children, topicIdInit }: IProviderProps
             saveMindmap,
             hasInitialized,
             fitView,
+            setIsNodeSheetOpen,
         }),
         [
             tab,
@@ -273,14 +276,11 @@ export function TopicWorkspaceProvider({ children, topicIdInit }: IProviderProps
             saveMindmap,
             hasInitialized,
             fitView,
+            setIsNodeSheetOpen,
         ],
     );
 
-    return (
-        
-            <TopicWorkspaceContext.Provider value={value}>{children}</TopicWorkspaceContext.Provider>
-        
-    );
+    return <TopicWorkspaceContext.Provider value={value}>{children}</TopicWorkspaceContext.Provider>;
 }
 
 export function useTopicWorkspace() {

--- a/src/app/[locale]/topics/[topicId]/(topic)/page.tsx
+++ b/src/app/[locale]/topics/[topicId]/(topic)/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import TopicWorkspace from './components/workspace/TopicWorkspace';
 import { TopicWorkspaceProvider } from './context/TopicWorkspaceContext';
 import { withAuth } from '@/hoc/withAuth';
+import { MindMapProvider } from '@/app/[locale]/mindmap/context/MindMapContext';
 
 const TopicPage = () => {
     const params = useParams();
@@ -19,9 +20,11 @@ const TopicPage = () => {
     const topicId = Number(params.topicId);
 
     return (
-        <TopicWorkspaceProvider topicIdInit={topicId}>
-            <TopicWorkspace />
-        </TopicWorkspaceProvider>
+        <MindMapProvider>
+            <TopicWorkspaceProvider topicIdInit={topicId}>
+                <TopicWorkspace />
+            </TopicWorkspaceProvider>
+        </MindMapProvider>
     );
 };
 

--- a/src/stores/features/mindmap/selectedNodeSlice.ts
+++ b/src/stores/features/mindmap/selectedNodeSlice.ts
@@ -31,6 +31,9 @@ export const selectedNodeSlice = createSlice({
         setSelectedNodeData: (state, action: PayloadAction<CustomNodeData>) => {
             state.selectedNodeData = action.payload;
         },
+        clearSelectedNodeData: (state) => {
+            state.selectedNodeData = undefined;
+        },
         toggleNodeSelection: (state, action: PayloadAction<string>) => {
             const nodeId = action.payload;
             const index = state.selectedNodeIds.indexOf(nodeId);
@@ -61,6 +64,7 @@ export const {
     closeSheet,
     setIsSheetOpen,
     setSelectedNodeData,
+    clearSelectedNodeData,
     toggleNodeSelection,
     clearNodeSelection,
     setMultiSelectMode,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roadmap panel added to the mindmap UI (rendered in both main layout and inside the canvas) with a visible "Roadmap" label for easier access.

* **Refactor**
  * Context composition updated so mindmap state and controls are available across topic/workspace views; provider order adjusted.

* **Changes**
  * Tooltip removed — button now shows its label.
  * Hover "More" ghost icon added on nodes to open node actions.

* **Bug Fixes**
  * Added action to clear selected node data on cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->