### PR TITLE
chore(eslint): disable explicit function return type rule in ESLint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
                 'jsx-a11y/anchor-is-valid': 'off',
                 '@typescript-eslint/no-explicit-any': 'error',
                 '@typescript-eslint/no-empty-function': 'error',
-                '@typescript-eslint/explicit-function-return-type': 'warn',
+                '@typescript-eslint/explicit-function-return-type': 'off',
                 '@typescript-eslint/explicit-module-boundary-types': 'off',
                 '@typescript-eslint/no-unused-vars': ['error'],
                 'import/no-cycle': 'off',


### PR DESCRIPTION
…onfiguration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to relax TypeScript return-type requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->